### PR TITLE
Add warning to documentation that the React tutorial is outdated

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -19,6 +19,7 @@ Getting started with Apollo is easy! You can follow these tutorials for step by 
 <h3 id="full-stack-graphql" title="Full stack tutorial"><a href="https://dev-blog.apollodata.com/full-stack-react-graphql-tutorial-582ac8d24e3b">Full Stack React and GraphQL Tutorial</a></h3>
 
 Jonas Helfer and friends take you through [building a simple GraphQL server and React app](https://dev-blog.apollodata.com/full-stack-react-graphql-tutorial-582ac8d24e3b) with Apollo.
+> The tutorial was written for Apollo 1.0 and has not yet been updated for Apollo 2.0
 
 <h3 id="howtographql">How to GraphQL</h3>
 


### PR DESCRIPTION
A warning like the proposed one would have saved me three hours today. I kept trying to follow the tutorial and I kept running into errors thinking I was doing something wrong. But then it finally donned on me to look at the comments and I saw other people reporting the same problems. Having a warning here and ideally also at the linked blog post would help people who are trying to get up-to-speed on Apollo a lot of time and grief.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->