### PR TITLE
Guides for Performance, Caching, Organization and Testing

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,7 +17,10 @@ sidebar_categories:
     - guides/security
     - guides/access-control
     - guides/monitoring
-    - guides/state-mgmt
+    - guides/performance
+    - guides/organization
+    - guides/caching
+    - guides/testing
   Documentation:
     - title: Apollo Client
       href: https://www.apollographql.com/docs/react/

--- a/docs/source/guides/caching.md
+++ b/docs/source/guides/caching.md
@@ -18,5 +18,5 @@ If our application has a lot of public data that doesn’t change very frequentl
 
 A CDN will store our API result close to the “edge” of the network — that is, close to the region the user is in — and deliver a cached result much faster than it would have required to do a full round trip to our actual server. As an added benefit, we get to save on server load since that query doesn’t actually hit our API.
 
-* Setting up CDN caching with Apollo Server is incredibly easy, simply setup Apollo Engine then follow this [guide](https://www.apollographql.com/docs/engine/cdn.html)
-* For more information about using a CDN with Apollo Engine, check out this [article](https://dev-blog.apollodata.com/caching-graphql-results-in-your-cdn-54299832b8e2)
+* Setting up CDN caching with Apollo Server is incredibly easy, simply setup Apollo Engine then follow this [guide.](https://www.apollographql.com/docs/engine/cdn.html)
+* For more information about using a CDN with Apollo Engine, check out this [article.](https://dev-blog.apollodata.com/caching-graphql-results-in-your-cdn-54299832b8e2)

--- a/docs/source/guides/caching.md
+++ b/docs/source/guides/caching.md
@@ -1,0 +1,22 @@
+---
+title: "Caching"
+description: "Caching operations"
+---
+
+One of the best ways we can speed up our application is to implement caching into it. Apollo Client has an intelligent cache which greatly lowers the work the client needs to do to fetch and manage data, but what about our server? Caching in Apollo Server can be done in a number of ways, but we recommend three in particular that have a good balance between complexity to manage and benefit of use.
+
+<h2 id="whole-query">Whole query caching</h2>
+
+GraphQL operations on a client are best when they are statically defined and used in an application. When this is the case, often times there will be operations that could easily be cached as a full result of the the request. We call this _whole query caching_ and it is incredibly easy to implement with Apollo Engine. Unlike custom REST endpoints, using Apollo Server allows us to define the cacheability of our resources and dynamically calculate the best possible cache timing for any given operation. If Apollo Server is configured to use Apollo Engine, caching is setup automatically with default configuration.
+
+* For more information about setting up Apollo Engine with Apollo Server, [read this guide]()
+* For more information about setting up whole query caching with Apollo Engine, [read this guide](https://www.apollographql.com/docs/engine/caching.html)
+
+<h2 id="cdn-caching">CDN integration</h2>
+
+If our application has a lot of public data that doesn’t change very frequently, and it’s important for it to load quickly, we will probably benefit from using a CDN to cache our API results. This can be particularly important for media or content companies like news sites and blogs.
+
+A CDN will store our API result close to the “edge” of the network — that is, close to the region the user is in — and deliver a cached result much faster than it would have required to do a full round trip to our actual server. As an added benefit, we get to save on server load since that query doesn’t actually hit our API.
+
+* Setting up CDN caching with Apollo Server is incredibly easy, simply setup Apollo Engine then follow this [guide](https://www.apollographql.com/docs/engine/cdn.html)
+* For more information about using a CDN with Apollo Engine, check out this [article](https://dev-blog.apollodata.com/caching-graphql-results-in-your-cdn-54299832b8e2)

--- a/docs/source/guides/organization.md
+++ b/docs/source/guides/organization.md
@@ -1,0 +1,261 @@
+---
+title: Organizing your code
+description: Scaling your Apollo Server from a single file to your entire team
+---
+
+The GraphQL schema defines the api for Apollo Server, providing the single source of truth between client and server. A complete schema contains type definitions and resolvers. Type definitions are written and documented in the [Schema Definition Language(SDL)]() to define the valid server entry points. Corresponding to one to one with type definition fields, resolvers are functions that retrieve the data described by the type definitions.
+
+To accommodate this tight coupling, type definitions and resolvers should be kept together in the same file. This collocation allows developers to modify fields and resolvers with atomic schema changes without unexpected consequences. At the end to build a complete schema, the type definitions are combined in an array and resolvers are merged together. Throughout all the examples, the resolvers delegate to a data model, as explained in [this section]().
+
+> Note: This schema separation should be done by product or real-world domain, which create natural boundaries that are easier to reason about.
+
+## Prerequisites
+
+* essentials/schema for connection between:
+  * GraphQL Types
+  * Resolvers
+
+<h2 id="organizing-types">Organizing schema types</h2>
+
+With large schema, defining types in different files and merge them to create the complete schema may become necessary. We accomplish this by importing and exporting schema strings, combining them into arrays as necessary. The following example demonstrates separating the type definitions of [this schema](#first-example-schema) found at the end of the page.
+
+```js
+// comment.js
+const typeDefs = gql`
+  type Comment {
+    id: ID!
+    message: String
+    author: String
+  }
+`;
+
+export typeDefs;
+```
+
+The `Post` includes a reference to `Comment`, which is added to the array of type definitions and exported:
+
+```js
+// post.js
+const typeDefs = `
+  type Post {
+    id: ID!
+    title: String
+    content: String
+    author: String
+    comments: [Comment]
+  }
+`;
+
+// Export Post and all dependent types
+export typeDefs;
+```
+
+Finally the root Query type, which uses Post, is created and passed to the server instantiation:
+
+```js
+// schema.js
+const Comment = require('./comment');
+const Post = require('./post');
+
+const RootQuery = `
+  type Query {
+    post(id: ID!): Post
+  }
+`;
+
+const server = new ApolloServer({
+  typeDefs: [RootQuery, Post.typeDefs, Comment.typeDefs],
+  resolvers, //defined in next section
+});
+
+server.listen().then(({ url }) => {
+  console.log(`🚀 Server ready at ${url}`)
+});
+```
+
+<h2 id="organizing-resolvers">Organizing resolvers</h2>
+
+For the type definitions above, we can accomplish the same modularity with resolvers by combining each type's resolvers together with Lodash's `merge` or another equivalent. The [end of this page](#first-example-resolvers) contains a complete view of the resolver map.
+
+```js
+// comment.js
+const CommentModel = require('./models/comment');
+
+const resolvers = {
+  Comment: {
+    votes: (parent) => CommentModel.getVotesById(parent.id)
+  }
+};
+
+export resolvers;
+```
+
+The `Post` type:
+
+```js
+// post.js
+const PostModel = require('./models/post');
+
+const resolvers = {
+  Post: {
+    comments: (parent) => PostModel.getCommentsById(parent.id)
+  }
+};
+
+export resolvers;
+```
+
+Finally, the Query type's resolvers are merged and the result is passed to the server instantiation:
+
+```js
+// schema.js
+const { merge } = require('lodash');
+const Post = require('./post');
+const Comment = require('./comment');
+
+const PostModel = require('./models/post');
+
+// Merge all of the resolver objects together
+const resolvers = merge({
+  Query: {
+    post: (_, args) => PostModel.getPostById(args.id)
+  }
+}, Post.resolvers, Comment.resolvers);
+
+const server = new ApolloServer({
+  typeDefs, //defined in previous section
+  resolvers,
+});
+
+server.listen().then(({ url }) => {
+  console.log(`🚀 Server ready at ${url}`)
+});
+```
+
+<h2 id="extend-types">Extending types</h2>
+
+The `extend` keyword provides the ability to add fields to existing types. Using `extend` is particularly useful in avoiding a large list of fields on root Queries and Mutations.
+
+```js
+//schema.js
+const bookTypeDefs = `
+extend type Query {
+  books: [Bar]
+}
+
+type Book {
+  id: ID!
+}
+`;
+
+// These type definitions are often in a separate file
+const authorTypeDefs = `
+extend type Query {
+  authors: [Author]
+}
+
+type Author {
+  id: ID
+}
+`;
+export const typeDefs = [bookTypeDefs, authorTypeDefs]
+```
+
+```js
+const {typeDefs, resolvers} = require('./schema');
+
+const rootQuery = `
+"Query can and must be defined once per schema to be extended"
+type Query {
+  _empty: String
+}`;
+
+const server = new ApolloServer({
+  typeDefs: [RootQuery].concat(typeDefs),
+  resolvers,
+});
+
+server.listen().then(({ url }) => {
+  console.log(`🚀 Server ready at ${url}`)
+});
+```
+
+> Note: In the current version of GraphQL, you can’t have an empty type even if you intend to extend it later. So we need to make sure the Query type has at least one field — in this case we can add a fake `_empty` field. Hopefully in future versions it will be possible to have an empty type to be extended later.
+
+<h2 id="descriptions">Documenting a Schema</h2>
+
+In addition to modularization, documentation within the SDL enables the schema to be effective as the single source of truth between client and server. Graphql gui's have built-in support for displaying docstrings with markdown syntax, such as those found in the following schema.
+
+```graphql
+"""
+Description for the type
+"""
+type MyObjectType {
+  """
+  Description for field
+  Supports multi-line description
+  """
+  myField: String!
+
+  otherField(
+    """
+    Description for argument
+    """
+    arg: Int
+  )
+}
+```
+
+<h2 id="api">API</h2>
+
+Apollo Server pass `typeDefs` and `resolvers` to the `graphql-tools`'s `makeExecutableSchema`.
+
+TODO point at graphql-tools `makeExecutableSchema` api
+
+<h2 id="example-app">Example Application Details</h2>
+
+<h3 id="example-schema">Schema</h3>
+
+The full type definitions for the first example:
+
+```graphql
+type Comment {
+  id: ID!
+  message: String
+  author: String
+  votes: Int
+}
+
+type Post {
+  id: ID!
+  title: String
+  content: String
+  author: String
+  comments: [Comment]
+}
+
+type Query {
+  post(id: ID!): Post
+}
+```
+
+<h3 id="example-resolvers">Resolvers</h3>
+
+The full resolver map for the first example:
+
+```js
+const CommentModel = require('./models/comment');
+const PostModel = require('./models/post');
+
+const resolvers = {
+  Comment: {
+    votes: (parent) => CommentModel.getVotesById(parent.id)
+  }
+  Post: {
+    comments: (parent) => PostModel.getCommentsById(parent.id)
+  }
+  Query: {
+    post: (_, args) => PostModel.getPostById(args.id)
+  }
+}
+```

--- a/docs/source/guides/organization.md
+++ b/docs/source/guides/organization.md
@@ -1,5 +1,5 @@
 ---
-title: Organizing your code
+title: Organization
 description: Scaling your Apollo Server from a single file to your entire team
 ---
 

--- a/docs/source/guides/performance.md
+++ b/docs/source/guides/performance.md
@@ -1,0 +1,211 @@
+---
+title: "Performance"
+description: "Reduce requests and speeding up applications"
+---
+
+GraphQL offers performance benefits for most applications. By reducing round-trips when fetching data, lower the amount of data we are sending back, and make it easier to batch data lookups. Since GraphQL is often built as a stateless request-response pattern, scaling our app horizontally becomes much easier. In this section, we will dive into some benefits that Apollo Server brings to our app, and some patterns for speeding up our service.
+
+<!-- TODO: this is a feature of GraphQL. Should this go here? -->
+
+## Prevent over-fetching
+
+Rest endpoints often return all of the fields for whatever data they are returning. As applications grow, their data needs grow as well, which leads to a lot of unnecessary data being downloaded by our client applications. With GraphQL this isn't a problem because Apollo Server will only return the data that we ask for when making a request! Take for example a screen which shows an avatar of the currently logged in user. In a rest app we may make a request to `/api/v1/currentUser` which would return a response like this:
+
+```json
+{
+ "id": 1,
+ "firstName": "James",
+ "lastName": "Baxley",
+ "suffix": "III",
+ "avatar": "/photos/profile.jpg",
+ "friendIds": [2, 3, 4, 5, 6, 7],
+ "homeId": 1,
+ "occupation": "farmer"
+ // and so on for every field on this model that our client **could** use
+}
+```
+
+Contrast that to the request a client would send to Apollo Server and the response they would receive:
+
+```graphql
+query GetAvatar {
+ currentUser {
+   avatar
+ }
+}
+```
+
+```json
+{
+ "data": {
+   "currentUser": {
+     "avatar": "/photos/profile.jpg"
+   }
+ }
+}
+```
+
+No matter how much our data grows, this query will always only return the smallest bit of data that the client application actually needs! This will make our app faster and our end users data plan much happier!
+
+<!-- TODO: this is a feature of GraphQL. Should this go here? -->
+
+## Reducing round-trips
+
+Applications typically need to fetch multiple resources to load any given screen for a user. When building an app on top of a REST API, screens need to fetch the first round of data, then using that information, make another request to load related information. A common example of this would be to load a user, then load their friends:
+
+```js
+const userAndFriends = fetch('/api/v1/user/currentUser').then(user => {
+ const friendRequest = Promise.all(
+   user.friendIds.map(id => fetch(`/api/vi/user/${id}`)),
+ );
+
+ return friendRequest.then(friends => {
+   user.friends = friends;
+   return user;
+ });
+});
+```
+
+The above code would make at minimum two requests, one for the logged in user and one for a single friend. With more friends, the number of requests jumps up quite a lot! To get around this, custom endpoints are added into a RESTful API. In this example, a `/api/v1/friends/:userId` may be added to make fetching friends a single request per user instead of one per friend.
+
+With GraphQL this is easily done in a single request! Given a schema like this:
+
+```graphql
+type User {
+ id: ID!
+ name: String!
+ friends: [User]
+}
+
+type Query {
+ currentUser: User
+}
+```
+
+We can easily fetch the current user and all of their friends in a single request!
+
+```graphql
+query LoadUserAndFriends {
+ currentUser {
+   id
+   name
+   friends {
+     id
+     name
+   }
+ }
+}
+```
+
+## Batching data lookups
+
+If we take the above query we may think GraphQL simply moves the waterfall of requests from the client to the server. Even if this was true, application speeds would still be improved. However, Apollo Server makes it possible to make applications even faster by batching data requests.
+
+The most common way to batch requests is by using Facebook's [`dataloader`](https://github.com/facebook/dataloader) library. Let's explore a few options for request batching the previous operation:
+
+<h3 id="custom-resolvers">Custom resolvers for batching</h3>
+
+The simplest (and often easiest) way to speed up a GraphQL service is to create resolvers that optimistically fetch the needed data. Often times the best thing to do is to write the simplest resolver possible to look up data, profile it with a tool like Apollo Engine, then improve slow resolvers with logic tuned for the way our schema is used. Take the above query, for example:
+
+```js
+const User = {
+ friends: (user, args, context) => {
+   // A simple approach to find each friend.
+   return user.friendIds.map(id => context.UserModel.findById(id));
+ },
+};
+```
+
+The above resolver will make a database lookup for the initial user and then one lookup for every friend that our user has. This would quickly turn into an expensive resolver to call so lets look at how we could speed it up! First, lets take a simple, but proven technique:
+
+```js
+const User = {
+ friends: (user, args, context) => {
+   // a custom model method for looking up multiple users
+   return context.UserModel.findByIds(user.friendIds);
+ },
+};
+```
+
+Instead of fetching each user independently, we could fetch all users at once in a single lookup. This would be analogous to `SELECT * FROM users WHERE id IN (1,2,3,4)` vs the previous query would have been multiple versions of `SELECT * FROM users WHERE id = 1`.
+
+Often times, custom resolvers are enough to speed up our server to the levels we want. However, there may be times where we want to be even more efficient when batching data. Lets say we expanded our operation to include more information:
+
+```graphql
+query LoadUserAndFriends {
+ currentUser {
+   id
+   name
+   friends {
+     id
+     name
+   }
+   family {
+     id
+     name
+   }
+ }
+}
+```
+
+Assuming that `family` returns more `User` types, we now are making at minimum three database calls: 1) the user, 2) the batch of friends, and 3) the batch of family members. If we expand the query deeper:
+
+```
+query LoadUserAndFriends {
+ currentUser {
+   id
+   name
+   friends {
+     id
+     name
+     ...peopleTheyCareAbout
+   }
+   family {
+     id
+     name
+     ...peopleTheyCareAbout
+   }
+ }
+}
+
+fragment peopleTheyCareAbout on User {
+ family {
+   id
+   name
+ }
+ friends {
+   id
+   name
+ }
+}
+```
+
+We are now looking at any number of database calls! The more friends and families that are connected in our app, the more expensive this query gets. Using a library like `dataloader`, we can reduce this operation to a maximum of three database lookups. Let's take a look at how to implement it to understand what is happening:
+
+```js
+const DataLoader = require('dataloader');
+
+// give this to ApolloServer's context
+const UserModelLoader = new DataLoader(UserModel.findByIds);
+
+// in the User resolvers
+const User = {
+ friends: (user, args, context) => {
+   return context.UserModelLoader.loadMany(user.friendIds);
+ },
+ family: (user, args, context) => {
+   return context.UserModelLoader.loadMany(user.familyIds);
+ },
+};
+```
+
+After the first data request returns with our current user's information, we execute the resolvers for `friends` and `family` within the same "tick" of the event loop, which is technical talk for "pretty much at the same time". DataLoader will delay making a data request (in this case the `UserModel.findByIds` call) long enough for it to capture the request to look up both friends and families at once! It will combine the two arrays of ids into one so our `SELECT * FROM users WHERE id IN ...` request will contain the ids of both friends **and** families!
+
+The friends and families request will return at the same time so when we select friends and families for all of previously returned users, the same batching can occur across all of the new users requests! So instead of potentially hundreds of data lookups, we can only perform 3 for a query like this!
+
+## Scaling our app
+
+Horizontal scaling is a fantastic way to increase the amount of load that our servers can handle without having to purchase more expensive computing resources to handling it. Apollo Server can scale extremely well like this as long as a couple of concerns are handled:
+
+* Every request should ensure it has access to the required data source. If we are building on top of a HTTP endpoint this isn't a problem, but when using a database it is a good practice to verify our connection on each request. This helps to make our app more fault tolerant and easily scale up a new service which will connect as soon as requests start!
+* Any state should be saved into a shared stateful datastore like redis. By sharing state, we can easily add more and more servers into our infrastructure without fear of loosing any kind of state between scale up and scale down.

--- a/docs/source/guides/testing.md
+++ b/docs/source/guides/testing.md
@@ -1,0 +1,74 @@
+---
+title: "Testing"
+description: "Testing your apps for peace of mind"
+---
+
+Testing a GraphQL Server is something that many people think of as essential for production use. Luckily, the execution model of GraphQL Servers makes testing every aspect of the server possible. The natural separation of concerns that GraphQL encourages makes unit and integration testing a much more enjoyable process.
+
+The following sections intend to walk through everything you need to start testing your Apollo Server.
+
+> (James) Add API for ApolloServer to make it easy to run integration tests against? Dependency injection anyone?
+
+## Unit testing resolvers
+
+The structure of our resolvers help to make them testable. If models, fetchers, and database connections live on the context, resolvers can be tested through mocking those dependencies alone. For example, suppose we have a resolver that we use to look up a user by their id (an argument):
+
+```js
+const resolvers = {
+ user: (root, args, context) => {
+   if (!context.user) throw new Error('You must be logged in to do this');
+   return context.models.User.getById(args.id);
+ },
+};
+module.exports = resolvers;
+```
+
+But what exactly should be tested in a resolver? A few things that are good to verify in tests are:
+
+The field can’t be accessed with improper user roles or a logged out user (unless the field is public)
+The resolver calls any data fetching models/connections with the proper arguments
+The resolver returns data from the data fetching models/connections properly
+
+**Getting started with resolver tests**
+
+For these examples, we'll be using the [Jest]() testing framework, but the concepts should be similar with other tools. An initial test for this resolver would look something like this:
+
+```js
+const resolvers = require('./user');
+
+it('should return a user object', () => {
+ // a fake context that has everything our resolver needs
+ const mockContext = {
+   user: { token: '12345' },
+   models: {
+     User: {
+       getById: jest.fn(() => ({ name: 'foo', age: 100 })),
+     },
+   },
+ };
+
+ const mockArgs = { id: 123 };
+
+ // run the resolver and expect it to give us a user object back
+ expect(resolvers.user(null, mockArgs, mockContext)).toEqual({
+   name: 'foo',
+   age: 100,
+ });
+});
+```
+
+So what exactly are we doing here? The `it` function is just a wrapper for a test. It tells Jest that this function contains a test and gives it a name. At the bottom, the `expect` function is our actual test. Expect functions can be read aloud to make more sense. Their shape normally reads something like an English sentence, `expect(result).toEqual(ourExpectedResult)`.
+
+At the top of the test, we create a fake context object, `mockContext`, that has everything our resolver needs on the context (the third argument). If we look at the resolver code, we see that it expects someone to be logged in (`context.user`) and a user model (`context.models.User`) so we create those both in our `mockContext`
+
+* dependency injection for context/fetchers
+* expect models to be called with correct args
+* expect transforms of data from models to be accurate
+
+## Integration testing operations
+
+* https://gist.github.com/JakeDawkins/84d810d96cc1b36ed270bc09ba148816
+
+## Using your schema to mock data for client testing
+
+* gather info on this


### PR DESCRIPTION
This is the initial content for the `Performance`, `Caching`, `Organization` and `Testing` guides.

IMO. The testing should be further divided into two guides: `Testing for Client` and `Testing for Server`. @excitement-engineer's [PR](https://github.com/apollographql/apollo-client/pull/3309) for react-apollo should come in handy for client testing cc @JakeDawkins.

@Poincare started writing the `Organization` guide. He just submitted a recent [PR](https://github.com/apollographql/apollo/pull/161) with more details around schema organization and resolvers. This should override the one here but I didn't merge it yet because we need feedback from everyone.

`Caching` should be pretty straightforward.

@stubailo @abernix @peggyrayzis please review.