### PR TITLE
React Apollo Testing

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,6 +18,7 @@ sidebar_categories:
     - guides/access-control
     - guides/monitoring
     - guides/state-mgmt
+    - guides/testing-react-apollo
   Documentation:
     - title: Apollo Client
       href: https://www.apollographql.com/docs/react/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,7 +18,7 @@ sidebar_categories:
     - guides/access-control
     - guides/monitoring
     - guides/state-mgmt
-    - guides/testing-react-apollo
+    - guides/testing-react-components
   Documentation:
     - title: Apollo Client
       href: https://www.apollographql.com/docs/react/

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -145,8 +145,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "async": {
       "version": "0.2.10",
@@ -531,7 +530,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -678,8 +676,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "delegate": {
       "version": "3.2.0",
@@ -855,8 +852,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -950,8 +946,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -1017,7 +1012,6 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "inherits": "2.0.3"
           }
@@ -1026,7 +1020,6 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -1043,8 +1036,7 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -1061,14 +1053,12 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
@@ -1081,20 +1071,17 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -1134,8 +1121,7 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -1167,8 +1153,7 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -1196,7 +1181,6 @@
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
@@ -1264,8 +1248,7 @@
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -1293,7 +1276,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -1341,7 +1323,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -1355,8 +1336,7 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -1429,14 +1409,12 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "mime-db": "1.27.0"
           }
@@ -1452,14 +1430,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1514,8 +1490,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -1573,8 +1548,7 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -1612,7 +1586,6 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-shims": "1.0.0",
             "core-util-is": "1.0.2",
@@ -1664,8 +1637,7 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "semver": {
           "version": "5.3.0",
@@ -1689,7 +1661,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -1723,7 +1694,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -1734,7 +1704,6 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.0.1"
           }
@@ -1749,7 +1718,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
@@ -1764,7 +1732,6 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "block-stream": "0.0.9",
             "fstream": "1.0.11",
@@ -1820,8 +1787,7 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -2605,7 +2571,6 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -2667,8 +2632,7 @@
           "version": "2.16.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
           "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -2881,7 +2845,7 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
           "requires": {
-            "sprintf-js": "~1.0.2"
+            "sprintf-js": "1.0.3"
           }
         },
         "balanced-match": {
@@ -2894,7 +2858,7 @@
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "requires": {
-            "inherits": "~2.0.0"
+            "inherits": "2.0.3"
           }
         },
         "bluebird": {
@@ -2907,7 +2871,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2934,9 +2898,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
           "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
           }
         },
         "fs.realpath": {
@@ -2949,10 +2913,10 @@
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
           }
         },
         "glob": {
@@ -2960,12 +2924,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
@@ -2978,8 +2942,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -2997,8 +2961,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
           "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
           }
         },
         "jsonfile": {
@@ -3006,7 +2970,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         },
         "minimatch": {
@@ -3014,7 +2978,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -3040,7 +3004,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-tmpdir": {
@@ -3063,7 +3027,7 @@
           "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
           "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
           "requires": {
-            "resolve": "^1.1.6"
+            "resolve": "1.5.0"
           }
         },
         "resolve": {
@@ -3071,7 +3035,7 @@
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
           "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
           "requires": {
-            "path-parse": "^1.0.5"
+            "path-parse": "1.0.5"
           }
         },
         "rimraf": {
@@ -3079,7 +3043,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "shelljs": {
@@ -3087,9 +3051,9 @@
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
           "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
           "requires": {
-            "glob": "^7.0.0",
-            "interpret": "^1.0.0",
-            "rechoir": "^0.6.2"
+            "glob": "7.1.2",
+            "interpret": "1.1.0",
+            "rechoir": "0.6.2"
           }
         },
         "simple-git": {
@@ -3097,7 +3061,7 @@
           "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.89.0.tgz",
           "integrity": "sha1-71L+c01QYFZs4Yeyu6zjbCMj40w=",
           "requires": {
-            "debug": "^3.1.0"
+            "debug": "3.1.0"
           }
         },
         "sprintf-js": {
@@ -3110,9 +3074,9 @@
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         },
         "tarball-extract": {
@@ -3121,7 +3085,7 @@
           "integrity": "sha1-FQ5sAR3mdkeRn67CUDVhHGdh/RA=",
           "requires": {
             "tar": "2.2.1",
-            "wget": "*"
+            "wget": "0.0.1"
           }
         },
         "tmp": {
@@ -3129,7 +3093,7 @@
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "requires": {
-            "os-tmpdir": "~1.0.2"
+            "os-tmpdir": "1.0.2"
           }
         },
         "tmp-promise": {
@@ -3137,7 +3101,7 @@
           "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.4.tgz",
           "integrity": "sha512-76r7LZhAvRJ3kLD/xrPSEGb3aq0tirzMLJKhcchKSkQIiEgXB+RouC0ygReuZX+oiA64taGo+j+1gHTKSG8/Mg==",
           "requires": {
-            "bluebird": "^3.5.0",
+            "bluebird": "3.5.1",
             "tmp": "0.0.33"
           }
         },
@@ -3197,15 +3161,13 @@
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
       "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
-      "optional": true,
       "requires": {
         "mime-db": "1.30.0"
       }
@@ -3423,7 +3385,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
-      "optional": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -4157,8 +4118,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",

--- a/docs/source/guides/testing-react-apollo.md
+++ b/docs/source/guides/testing-react-apollo.md
@@ -1,0 +1,305 @@
+---
+title: Testing React Apollo
+description: Have peace of mind when using React-Apollo in production
+---
+
+TODO: Intoduction
+
+Running tests against code meant for production has long been a best practice. It provides additional security for the code that's already written, as well as prevents accidental regressions in the future. Components utilizing React Apollo are no exception.
+
+Although React Apollo has a lot going on under the hood, the library provides multiple tools for testing that simplify those abstractions, and allows complete focus on the component logic. These testing utilities have long been used to test the React Apollo library itself, so developers can trust in their stability and long-term support.
+
+## An introduction
+
+React Apollo relies on [context](https://reactjs.org/docs/context.html) in order to pass the Apollo Client instance through the React component tree. In addition, React Apollo makes network requests in order to fetch data. This behavior affects how you write tests for components that use React Apollo.
+
+This guide will explain step-by-step how you can test your React Apollo code. The following examples will be using the [Jest](https://facebook.github.io/jest/docs/en/tutorial-react.html) testing framework, but most concepts should be reusable with other libraries. These examples also show the basic [Test renderer](https://reactjs.org/docs/test-renderer.html) from the React library.
+
+Consider the example below:
+
+```js
+import React from 'react';
+import gql from 'graphql-tag';
+import { Query } from 'react-apollo';
+
+// make sure the query is also exported -- not just the component
+export const GET_DOG_QUERY = gql`
+  query getDog($name: String) {
+    dog(name: $name) {
+      id
+      name
+      breed
+    }
+  }
+`;
+
+export const Dog = ({ name }) => (
+  <Query query={GET_DOG_QUERY} variables={{ name }}>
+    {({ loading, error, data }) => {
+      if (loading) return 'Loading...';
+      if (error) return `Error! ${error.message}`;
+
+      return (
+        <div id="dog-info">
+          {data.dog.name} has breed {data.dog.breed}
+        </div>
+      );
+    }}
+  </Query>
+);
+```
+
+If we were to try and write a test for the `<Dog />` component then you will get an error that the `client` is missing in the context.
+
+```js
+// Broken because it's missing Apollo Client in the context
+it('should render without error', () => {
+  renderer.create(<Dog />);
+});
+```
+
+In order to fix this we could wrap the component in an `ApolloProvider` and pass an instance of Apollo Client to the `client` prop. However, this will cause our tests to run against an actual backend which makes the tests very unpredictable for the following reasons:
+
+- The server could be down
+- There may be no network connection
+- The results are not guaranteed to be the same for every query
+
+```js
+// Not predictable
+it('renders without error', () => {
+  renderer.create(
+    <ApolloProvider client={client}>
+      <Dog name="Buck" />
+    </ApolloProvider>,
+  );
+});
+```
+
+## MockedProvider
+
+To test the component in true isolation, mock all calls to the GraphQL endpoint. This makes the UI consistent every time tests are run.
+
+React Apollo provides the `MockedProvider` component in the `react-apollo/test-utils` library to do just that! `MockedProvider` allows specifying the exact results that should be returned for a certain query using the `mocks` prop.
+
+Here's an example of a test for the above `Dog` component using `MockedProvider`:
+
+```js
+// dog.test.js
+
+import { MockedProvider } from 'react-apollo/test-utils';
+
+// The component AND the query need to be exported
+import { GET_DOG_QUERY, Dog } from './dog';
+
+const mocks = [
+  {
+    request: {
+      query: GET_DOG_QUERY,
+      variables: {
+        name: 'Buck',
+      },
+    },
+    result: {
+      data: {
+        dog: { id: '1', name: 'Buck', breed: 'bulldog' },
+      },
+    },
+  },
+];
+
+it('renders without error', () => {
+  renderer.create(
+    <MockedProvider mocks={mocks}>
+      <Dog name="Buck" />
+    </MockedProvider>,
+  );
+});
+```
+
+This file shows how to define the mocked response for a query. The `mocks` array takes objects with specific `request`s and their associated `result`s. In this example, when the provider receives a `GET_DOG_QUERY` it returns the object under the `result` key.
+
+<!-- PICK UP HERE WITH TALKING ABOUT LOADING STATE -->
+
+Despite having mocked the request the above test will still fail. React Apollo will first show a loading state before it successfully retrieves the data and renders the dog name.
+
+In order to overcome this issue you can separate the React Apollo components from presentational components and test these independently.
+
+Let's see how we can refactor the code to improve testability.
+
+```js
+export const GET_DOG = gql`
+query getDog($name: String) {
+  dog(name: $name) {
+    id
+    name
+    breed
+  }
+}
+`;
+
+// The React Apollo component
+export const DogQuery = ({ children, name }) => (
+  <Query query={GET_DOG} variables={{name}}>
+    {({ loading, error, data }) =>
+      children({
+        loading,
+        error,
+        dog: data && data.dog
+      })
+    }
+  </Query>
+);
+
+// The presentational component
+export const DogInterface = props => {
+  const { loading, error, dog } = props;
+  if (loading) return "Loading...";
+  if (error) return `Error! ${error.message}`;
+
+  return <div>{dog.name} has breed {dog.breed}</div>;
+};
+
+// Connecting the components together.
+export const Dog = props => (
+  <DogQuery name={props.name}>{result => <DogInterface {...result} />}</DogInterface>
+);
+```
+
+Let's go back to our test file and see how we can test the `<DogQuery />` component.
+
+```js
+import { GET_DOG, DogQuery } from "./dog";
+
+const expectedRequest = {
+  query: GET_DOG,
+  name: "Buck"
+}
+
+const mocks = [
+  {
+    request: expectedRequest,
+    result: {
+      data: {
+        dog: {
+          id: "1",
+          name: "Buck",
+          breed: "bulldog"
+        }
+      }
+    }
+  }
+];
+
+describe("dog with query", () => {
+  it("renders a loading and then dog", done => {
+    let renderCount = 0;
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <DogQuery name="Buck">
+          {result => {
+            if (renderCount === 0) {
+              // The first render has the loading state
+              expect(result.loading).toBe(true);
+              expect(result.dog).toBe(undefined);
+            }
+            else if (renderCount === 1) {
+              // The second render has the data.
+              expect(result.loading).toBe(false);
+              expect(result.dog).toEqual({
+                  id: "1",
+                  name: "Buck",
+                  breed: "bulldog"
+              });
+              done()
+            }
+
+            renderCount++;
+
+            return null;
+          }}
+        </DogWithQuery>
+      </MockedProvider>
+    );
+  });
+
+  it("renders an error", done => {
+    //<MockedProvider /> can also be used to test error states.
+    const mocksWithError = [
+      {
+        request: expectedRequest,
+        error: new Error('Something went wrong'),
+      },
+    ];
+
+    let renderCount = 0;
+
+    render(
+        <MockedProvider mocks={mocksWithError}>
+          <DogQuery name="Buck">
+            {result => {
+              // Second render has the error state
+              if (renderCount === 1) {
+                expect(result).toEqual({
+                  error: new Error('Network error: Something went wrong'),
+                  loading: false,
+                });
+                done();
+              }
+
+              renderCount++;
+              return null;
+            }}
+          </HeroQuery>
+        </MockedProvider>
+    );
+  })
+});
+```
+
+Next, let's test the `<DogInterface />` component:
+
+```js
+describe("<DogInterface />", () => {
+  it("renders the dog", () => {
+    const dog = {
+      id: "1"
+      name: "Buck",
+      breed: "bulldog"
+    };
+
+    render(<DogInterface dog={dog} />);
+    expect(dogToBeShown);
+  });
+
+  it("renders a loading state", () => {
+    render(<DogInterface loading={true} />);
+    expect(loadingToBeShown);
+  });
+
+  it("renders an error state", () => {
+    render(<DogInterface error={new Error("Something went wrong")} />);
+    expect(errorToBeShown);
+  });
+});
+```
+
+Finally, we need to test that the `<Dog />` component has correctly connected the `<DogQuery />` and `<DogInterface />` together.
+
+```js
+it('renders <Dog />', () => {
+  render(
+    <MockedProvider mocks={mocks}>
+      <Dog name="Buck" />
+    </MockedProvider>,
+  );
+
+  expect(loadingToBeShown);
+});
+```
+
+We have now successfully tested the code!
+
+In case you want some more information, we have created an [example repo](https://github.com/apollographql/react-apollo/tree/master/examples/components) that illustrates how you can use the techniques outlined in this guide to test your components.
+
+Refer to the [docs](../api/react-apollo.html#MockedProvider) for more information on the API for `<MockedProvider />`.

--- a/docs/source/guides/testing-react-apollo.md
+++ b/docs/source/guides/testing-react-apollo.md
@@ -116,11 +116,11 @@ it('renders without error', () => {
 });
 ```
 
-This example shows how to define the mocked response for a query. The `mocks` array takes objects with specific `request`s and their associated `result`s. In this example, when the provider receives a `GET_DOG_QUERY` witht the specified variables, it returns the object under the `result` key.
+This example shows how to define the mocked response for a query. The `mocks` array takes objects with specific `request`s and their associated `result`s. In this example, when the provider receives a `GET_DOG_QUERY` with the specified variables, it returns the object under the `result` key.
 
 ### addTypename
 
-You may notice the prop being passed to the MockedProvider called `addTypename`. The reason this is here is because of how Apollo Client normally works. When a request is made with Apollo Client normally, it adds a `__typename` field to every object type requested. This is to make sure that Apollo Client's cache knows how to normalize and store the response. When we're making our mocks, though, we're importing the raw queries _without typenames_ from the component files.
+You may notice the prop being passed to the `MockedProvider` called `addTypename`. The reason this is here is because of how Apollo Client normally works. When a request is made with Apollo Client normally, it adds a `__typename` field to every object type requested. This is to make sure that Apollo Client's cache knows how to normalize and store the response. When we're making our mocks, though, we're importing the raw queries _without typenames_ from the component files.
 
 If we don't disable the adding of typenames to queries, our imported query won't match the query actually being run by the component during our tests.
 
@@ -150,6 +150,8 @@ This example shows how to (very basically) test loading state of a component. He
 Loading state, while important, isn't the only thing to test. To test the final state of the component after receiving data, we can just wait for it to update and test the final state.
 
 ```js
+const wait = require('waait');
+
 it('should render currency conversions', async () => {
   const dogMock = {
     request: {
@@ -174,7 +176,7 @@ it('should render currency conversions', async () => {
 });
 ```
 
-Here, you can see the `await wait(0)` line. This artificially adds a delay, and allows time for that promise returned from `MockedProvider` to resolve. After that promise resolves, we can check the component to make sure it displays the correct information (in this case, "Buck is a poodle").
+Here, you can see the `await wait(0)` line. This is a util function from a npm package called `waait`.This artificially adds a delay, and allows time for that promise returned from `MockedProvider` to resolve. After that promise resolves, we can check the component to make sure it displays the correct information (in this case, "Buck is a poodle").
 
 ## Testing error states
 

--- a/docs/source/guides/testing-react-apollo.md
+++ b/docs/source/guides/testing-react-apollo.md
@@ -3,11 +3,9 @@ title: Testing React Apollo
 description: Have peace of mind when using React-Apollo in production
 ---
 
-TODO: Intoduction
-
 Running tests against code meant for production has long been a best practice. It provides additional security for the code that's already written, as well as prevents accidental regressions in the future. Components utilizing React Apollo are no exception.
 
-Although React Apollo has a lot going on under the hood, the library provides multiple tools for testing that simplify those abstractions, and allows complete focus on the component logic. These testing utilities have long been used to test the React Apollo library itself, so developers can trust in their stability and long-term support.
+Although React Apollo has a lot going on under the hood, the library provides multiple tools for testing that simplify those abstractions, and allows complete focus on the component logic. These testing utilities have long been used to test the React Apollo library itself, so you can trust in their stability and long-term support.
 
 ## An introduction
 
@@ -49,7 +47,7 @@ export const Dog = ({ name }) => (
 );
 ```
 
-If we were to try and write a test for the `<Dog />` component then you will get an error that the `client` is missing in the context.
+If we were to try and write a test for the `<Dog />` component then we would get an error that the `client` is missing in the context.
 
 ```js
 // Broken because it's missing Apollo Client in the context
@@ -77,9 +75,9 @@ it('renders without error', () => {
 
 ## MockedProvider
 
-To test the component in true isolation, mock all calls to the GraphQL endpoint. This makes the UI consistent every time tests are run.
+To test the component in true isolation, we can mock all calls to the GraphQL endpoint. This makes the UI consistent every time tests are run, since they don't depend on any remote data.
 
-React Apollo provides the `MockedProvider` component in the `react-apollo/test-utils` library to do just that! `MockedProvider` allows specifying the exact results that should be returned for a certain query using the `mocks` prop.
+React Apollo provides the `MockedProvider` component in the `react-apollo/test-utils` library to do just that! `MockedProvider` allows us to specify the exact results that should be returned for a certain query using the `mocks` prop.
 
 Here's an example of a test for the above `Dog` component using `MockedProvider`:
 
@@ -116,190 +114,198 @@ it('renders without error', () => {
 });
 ```
 
-This file shows how to define the mocked response for a query. The `mocks` array takes objects with specific `request`s and their associated `result`s. In this example, when the provider receives a `GET_DOG_QUERY` it returns the object under the `result` key.
+This example shows how to define the mocked response for a query. The `mocks` array takes objects with specific `request`s and their associated `result`s. In this example, when the provider receives a `GET_DOG_QUERY` witht the specified variables, it returns the object under the `result` key.
 
-<!-- PICK UP HERE WITH TALKING ABOUT LOADING STATE -->
-
-Despite having mocked the request the above test will still fail. React Apollo will first show a loading state before it successfully retrieves the data and renders the dog name.
-
-In order to overcome this issue you can separate the React Apollo components from presentational components and test these independently.
-
-Let's see how we can refactor the code to improve testability.
+In this example, the `Dog` component will render, but it will render in a loading state, not the final response state. This is because `MockedProvider` doesn't just return the data. It returns a promise that will resolve to that data. This allows testing of loading states as well as the final state.
 
 ```js
-export const GET_DOG = gql`
-query getDog($name: String) {
-  dog(name: $name) {
-    id
-    name
-    breed
-  }
-}
-`;
-
-// The React Apollo component
-export const DogQuery = ({ children, name }) => (
-  <Query query={GET_DOG} variables={{name}}>
-    {({ loading, error, data }) =>
-      children({
-        loading,
-        error,
-        dog: data && data.dog
-      })
-    }
-  </Query>
-);
-
-// The presentational component
-export const DogInterface = props => {
-  const { loading, error, dog } = props;
-  if (loading) return "Loading...";
-  if (error) return `Error! ${error.message}`;
-
-  return <div>{dog.name} has breed {dog.breed}</div>;
-};
-
-// Connecting the components together.
-export const Dog = props => (
-  <DogQuery name={props.name}>{result => <DogInterface {...result} />}</DogInterface>
-);
-```
-
-Let's go back to our test file and see how we can test the `<DogQuery />` component.
-
-```js
-import { GET_DOG, DogQuery } from "./dog";
-
-const expectedRequest = {
-  query: GET_DOG,
-  name: "Buck"
-}
-
-const mocks = [
-  {
-    request: expectedRequest,
-    result: {
-      data: {
-        dog: {
-          id: "1",
-          name: "Buck",
-          breed: "bulldog"
-        }
-      }
-    }
-  }
-];
-
-describe("dog with query", () => {
-  it("renders a loading and then dog", done => {
-    let renderCount = 0;
-
-    render(
-      <MockedProvider mocks={mocks}>
-        <DogQuery name="Buck">
-          {result => {
-            if (renderCount === 0) {
-              // The first render has the loading state
-              expect(result.loading).toBe(true);
-              expect(result.dog).toBe(undefined);
-            }
-            else if (renderCount === 1) {
-              // The second render has the data.
-              expect(result.loading).toBe(false);
-              expect(result.dog).toEqual({
-                  id: "1",
-                  name: "Buck",
-                  breed: "bulldog"
-              });
-              done()
-            }
-
-            renderCount++;
-
-            return null;
-          }}
-        </DogWithQuery>
-      </MockedProvider>
-    );
-  });
-
-  it("renders an error", done => {
-    //<MockedProvider /> can also be used to test error states.
-    const mocksWithError = [
-      {
-        request: expectedRequest,
-        error: new Error('Something went wrong'),
-      },
-    ];
-
-    let renderCount = 0;
-
-    render(
-        <MockedProvider mocks={mocksWithError}>
-          <DogQuery name="Buck">
-            {result => {
-              // Second render has the error state
-              if (renderCount === 1) {
-                expect(result).toEqual({
-                  error: new Error('Network error: Something went wrong'),
-                  loading: false,
-                });
-                done();
-              }
-
-              renderCount++;
-              return null;
-            }}
-          </HeroQuery>
-        </MockedProvider>
-    );
-  })
-});
-```
-
-Next, let's test the `<DogInterface />` component:
-
-```js
-describe("<DogInterface />", () => {
-  it("renders the dog", () => {
-    const dog = {
-      id: "1"
-      name: "Buck",
-      breed: "bulldog"
-    };
-
-    render(<DogInterface dog={dog} />);
-    expect(dogToBeShown);
-  });
-
-  it("renders a loading state", () => {
-    render(<DogInterface loading={true} />);
-    expect(loadingToBeShown);
-  });
-
-  it("renders an error state", () => {
-    render(<DogInterface error={new Error("Something went wrong")} />);
-    expect(errorToBeShown);
-  });
-});
-```
-
-Finally, we need to test that the `<Dog />` component has correctly connected the `<DogQuery />` and `<DogInterface />` together.
-
-```js
-it('renders <Dog />', () => {
-  render(
-    <MockedProvider mocks={mocks}>
-      <Dog name="Buck" />
+it('should render loading state initially', () => {
+  const component = renderer.create(
+    <MockedProvider mocks={[]}>
+      <Currency />
     </MockedProvider>,
   );
 
-  expect(loadingToBeShown);
+  const tree = component.toJSON();
+  expect(tree.children).toContain('Loading...');
 });
 ```
 
-We have now successfully tested the code!
+This example shows how to (very basically) test loading state of a component. Here, all we're checking is that the children of the component contain the text `Loading...`. In real apps, this test would probably be more complicated, but the testing logic would be the same.
 
-In case you want some more information, we have created an [example repo](https://github.com/apollographql/react-apollo/tree/master/examples/components) that illustrates how you can use the techniques outlined in this guide to test your components.
+## Testing final state
+
+Loading state, while important, isn't the only thing to test. To test the final state of the component after receiving data, we can just wait for it to update and test the final state.
+
+```js
+it('should render currency conversions', async () => {
+  const currencyMock = {
+    request: { query: GET_EXCHANGE_RATES_QUERY },
+    result: { data: { rates: [{ currency: 'LOL', rate: 999 }] } },
+  };
+
+  const component = renderer.create(
+    <MockedProvider mocks={[currencyMock]} addTypename={false}>
+      <Currency />
+    </MockedProvider>,
+  );
+
+  await wait(0); // wait for response
+
+  const p = component.root.findByType('p');
+  expect(p.children).toContain('LOL: 999');
+});
+```
+
+Here, you can see the `await wait(0)` line. This artificially adds a delay, and allows time for that promise returned from `MockedProvider` to resolve. After that promise resolves, we can check the component to make sure it displays the correct information (in this case, `LOL: 999`).
+
+<!-- talk about addTypename -->
+
+## Testing error states
+
+Error states are one of the most important states to test, since they can make or break the experience a user has when interacting with the app.
+
+Error states are also tested less in development. Since most developers would follow the "happy path" and not encounter these states as often, it's almost _more_ important to test these states to prevent accidental regressions.
+
+To simulate a GraphQL error, all you have to do is pass an `error` to your mock.
+
+```js
+it('should show error UI', async () => {
+  const currencyMock = {
+    request: { query: GET_EXCHANGE_RATES_QUERY },
+    error: new Error('aw shucks'),
+  };
+
+  const component = renderer.create(
+    <MockedProvider mocks={[currencyMock]} addTypename={false}>
+      <Currency />
+    </MockedProvider>,
+  );
+
+  await wait(0); // wait for response
+
+  const tree = component.toJSON();
+  expect(tree.children).toContain('Error :(');
+});
+```
+
+Here, whenever your `MockProvider` receives a `GET_EXCHANGE_RATES_QUERY`, it will return a GraphQL error. This forces the component into the error state, and we can verify that it's handling the error gracefully.
+
+## Testing mutation components
+
+`Mutation` components are tested very similarly to `Query` components. The only key difference is how the mutation is fired. With `Query` components, the query is fired when the component mounts. With `Mutation` components, the mutation is fired manually, usually after some user interaction like pressing a button.
+
+Consider this component that calls a mutation:
+
+```js
+export const DELETE_CURRENCY_MUTATION = gql`
+  mutation deleteCurrency($name: String!) {
+    deleteCurrency(name: $name) {
+      currency
+      rate
+    }
+  }
+`;
+
+export default () => (
+  <Mutation mutation={DELETE_CURRENCY_MUTATION}>
+    {(mutate, { loading, error, data }) => {
+      if (loading) return <p>Loading...</p>;
+      if (error) return <p>Error :(</p>;
+      if (data) return <p>Deleted!</p>;
+
+      return (
+        <button onClick={() => mutate({ variables: { name: 'USD' } })}>
+          Click me to Delete the USD!
+        </button>
+      );
+    }}
+  </Mutation>
+);
+```
+
+Testing an initial render for this component looks identical to testing our query component.
+
+```js
+import DeleteButton, { DELETE_CURRENCY_MUTATION } from './delete-currency';
+
+it('should render without error', () => {
+  renderer.create(
+    <MockedProvider mocks={[]}>
+      <DeleteButton />
+    </MockedProvider>,
+  );
+});
+```
+
+Calling the mutation is where things get interesting:
+
+```js
+it('should render loading state initially', () => {
+  const deleteCurrency = { currency: 'USD', rate: 1.0 };
+  const mocks = [
+    {
+      request: {
+        query: DELETE_CURRENCY_MUTATION,
+        variables: { name: 'USD' },
+      },
+      result: { data: { deleteCurrency } },
+    },
+  ];
+
+  const component = renderer.create(
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <DeleteButton />
+    </MockedProvider>,
+  );
+
+  // find the button and simulate a click
+  const button = component.root.findByType('button');
+  button.props.onClick(); // fires the mutation
+
+  const tree = component.toJSON();
+  expect(tree.children).toContain('Loading...');
+});
+```
+
+This example looks very similar to the `Query` component. The difference comes after the render. Since this component relies on a button to be clicked to fire a mutation, we first use the renderer's API to find that button.
+
+After we find the button, we can manually call the `onClick` prop to that button, simulating a user clicking the button. This click fires off the mutation, and then the rest is tested identically to the `Query` component.
+
+For example, to test for a successful mutation, you'd just wait for the promise to resolve from `MockedProvider` and check for any confirmation message in your UI, just like the `Query` component:
+
+```js
+it('should delete and give visual feedback', async () => {
+  const deleteCurrency = { currency: 'USD', rate: 1.0 };
+  const mocks = [
+    {
+      request: {
+        query: DELETE_CURRENCY_MUTATION,
+        variables: { name: 'USD' },
+      },
+      result: { data: { deleteCurrency } },
+    },
+  ];
+
+  const component = renderer.create(
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <DeleteButton />
+    </MockedProvider>,
+  );
+
+  // find the button and simulate a click
+  const button = component.root.findByType('button');
+  button.props.onClick(); // fires the mutation
+
+  await wait(0);
+
+  const tree = component.toJSON();
+  expect(tree.children).toContain('Deleted!');
+});
+```
+
+---
+
+## Conclusion
 
 Refer to the [docs](../api/react-apollo.html#MockedProvider) for more information on the API for `<MockedProvider />`.

--- a/docs/source/guides/testing-react-apollo.md
+++ b/docs/source/guides/testing-react-apollo.md
@@ -1,5 +1,5 @@
 ---
-title: Testing React with Apollo
+title: Testing React Components
 description: Have peace of mind when using react-apollo in production
 ---
 

--- a/docs/source/guides/testing-react-apollo.md
+++ b/docs/source/guides/testing-react-apollo.md
@@ -1,6 +1,6 @@
 ---
-title: Testing React Apollo
-description: Have peace of mind when using React Apollo in production
+title: Testing React with Apollo
+description: Have peace of mind when using react-apollo in production
 ---
 
 Running tests against code meant for production has long been a best practice. It provides additional security for the code that's already written, as well as prevents accidental regressions in the future. Components utilizing React Apollo are no exception.

--- a/docs/source/guides/testing-react-apollo.md
+++ b/docs/source/guides/testing-react-apollo.md
@@ -176,7 +176,9 @@ it('should render currency conversions', async () => {
 });
 ```
 
-Here, you can see the `await wait(0)` line. This is a util function from a npm package called `waait`.This artificially adds a delay, and allows time for that promise returned from `MockedProvider` to resolve. After that promise resolves, we can check the component to make sure it displays the correct information (in this case, "Buck is a poodle").
+Here, you can see the `await wait(0)` line. This is a util function from a npm package called `waait`.This artificially adds a delay until the next tick, and allows time for that promise returned from `MockedProvider` to resolve. After that promise resolves, we can check the component to make sure it displays the correct information (in this case, "Buck is a poodle").
+
+In some cases with complex UI, heavy calculations, or delays added into the render logic of a component, the `wait(0)` will not be long enough. In these cases, you could either increase the wait time or use a package like [wait-for-expect](https://github.com/TheBrainFamily/wait-for-expect) to wait until the render has happened. The risk of using a package like this everywhere by default is that _every_ test could take up to 5 seconds (or longer if you have increased the default timeout) to execute.
 
 ## Testing error states
 
@@ -293,6 +295,8 @@ This example looks very similar to the `Query` component. The difference comes a
 
 After we find the button, we can manually call the `onClick` prop to that button, simulating a user clicking the button. This click fires off the mutation, and then the rest is tested identically to the `Query` component.
 
+> Note: Other test utilities like [Enzyme](https://github.com/airbnb/enzyme) and [react-testing-library](https://github.com/kentcdodds/react-testing-library) have built-in tools for finding elements and simulating events, but the concept is the same: find the button, and simulate a click on it.
+
 For example, to test for a successful mutation, you'd just wait for the promise to resolve from `MockedProvider` and check for any confirmation message in your UI, just like the `Query` component:
 
 ```js
@@ -325,9 +329,11 @@ it('should delete and give visual feedback', async () => {
 });
 ```
 
+For the sake of simplicity, the error case for mutations hasn't been shown here, but testing mutation errors is exactly the same as testing query errors: just add an `error` to the mock, fire the mutation, and check the UI for error messages.
+
 Testing UI components isn't a simple issue, but hopefully with these tools, you can feel more confident when testing components dependent on data.
 
-For a working example showing how to test components, check out this example on CodeSandbox:
+For a working example showing how to test components, check out this project on CodeSandbox:
 
 [![Edit React-Apollo Testing](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/40k7j708n4)
 

--- a/docs/source/guides/testing-react-apollo.md
+++ b/docs/source/guides/testing-react-apollo.md
@@ -297,7 +297,7 @@ After we find the button, we can manually call the `onClick` prop to that button
 
 > Note: Other test utilities like [Enzyme](https://github.com/airbnb/enzyme) and [react-testing-library](https://github.com/kentcdodds/react-testing-library) have built-in tools for finding elements and simulating events, but the concept is the same: find the button, and simulate a click on it.
 
-For example, to test for a successful mutation, you'd just wait for the promise to resolve from `MockedProvider` and check for any confirmation message in your UI, just like the `Query` component:
+To test for a successful mutation after simulating the click, you'd just wait for the promise to resolve from `MockedProvider` and check for any confirmation message in your UI, just like the `Query` component:
 
 ```js
 it('should delete and give visual feedback', async () => {
@@ -329,7 +329,7 @@ it('should delete and give visual feedback', async () => {
 });
 ```
 
-For the sake of simplicity, the error case for mutations hasn't been shown here, but testing mutation errors is exactly the same as testing query errors: just add an `error` to the mock, fire the mutation, and check the UI for error messages.
+For the sake of simplicity, the error case for mutations hasn't been shown here, but testing `Mutation` errors is exactly the same as testing `Query` errors: just add an `error` to the mock, fire the mutation, and check the UI for error messages.
 
 Testing UI components isn't a simple issue, but hopefully with these tools, you can feel more confident when testing components dependent on data.
 

--- a/docs/source/guides/testing-react-apollo.md
+++ b/docs/source/guides/testing-react-apollo.md
@@ -1,6 +1,6 @@
 ---
 title: Testing React Apollo
-description: Have peace of mind when using React-Apollo in production
+description: Have peace of mind when using React Apollo in production
 ---
 
 Running tests against code meant for production has long been a best practice. It provides additional security for the code that's already written, as well as prevents accidental regressions in the future. Components utilizing React Apollo are no exception.
@@ -11,16 +11,16 @@ Although React Apollo has a lot going on under the hood, the library provides mu
 
 React Apollo relies on [context](https://reactjs.org/docs/context.html) in order to pass the Apollo Client instance through the React component tree. In addition, React Apollo makes network requests in order to fetch data. This behavior affects how you write tests for components that use React Apollo.
 
-This guide will explain step-by-step how you can test your React Apollo code. The following examples will be using the [Jest](https://facebook.github.io/jest/docs/en/tutorial-react.html) testing framework, but most concepts should be reusable with other libraries. These examples also show the basic [Test renderer](https://reactjs.org/docs/test-renderer.html) from the React library.
+This guide will explain step-by-step how you can test your React Apollo code. The following examples will be using the [Jest](https://facebook.github.io/jest/docs/en/tutorial-react.html) testing framework, but most concepts should be reusable with other libraries. These examples aim to use as simple of a toolset as possible, so React's [test renderer](https://reactjs.org/docs/test-renderer.html) will be used in place of something like [Enzyme](https://github.com/airbnb/enzyme).
 
-Consider the example below:
+Consider the component below, which makes a basic query, and displays its results:
 
 ```js
 import React from 'react';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
 
-// make sure the query is also exported -- not just the component
+// Make sure the query is also exported -- not just the component
 export const GET_DOG_QUERY = gql`
   query getDog($name: String) {
     dog(name: $name) {
@@ -35,26 +35,28 @@ export const Dog = ({ name }) => (
   <Query query={GET_DOG_QUERY} variables={{ name }}>
     {({ loading, error, data }) => {
       if (loading) return 'Loading...';
-      if (error) return `Error! ${error.message}`;
+      if (error) return `Error!`;
 
       return (
-        <div id="dog-info">
-          {data.dog.name} has breed {data.dog.breed}
-        </div>
+        <p>
+          {data.dog.name} is a {data.dog.breed}
+        </p>
       );
     }}
   </Query>
 );
 ```
 
-If we were to try and write a test for the `<Dog />` component then we would get an error that the `client` is missing in the context.
+Given this component, let's try to render it inside a test, just to make sure there are no render errors:
 
 ```js
 // Broken because it's missing Apollo Client in the context
 it('should render without error', () => {
-  renderer.create(<Dog />);
+  renderer.create(<Dog name="Buck" />);
 });
 ```
+
+If we ran this test, we would get an error because Apollo Client isn't available on the context for the `Query` component to consume.
 
 In order to fix this we could wrap the component in an `ApolloProvider` and pass an instance of Apollo Client to the `client` prop. However, this will cause our tests to run against an actual backend which makes the tests very unpredictable for the following reasons:
 
@@ -107,7 +109,7 @@ const mocks = [
 
 it('renders without error', () => {
   renderer.create(
-    <MockedProvider mocks={mocks}>
+    <MockedProvider mocks={mocks} addTypename={false}>
       <Dog name="Buck" />
     </MockedProvider>,
   );
@@ -116,13 +118,23 @@ it('renders without error', () => {
 
 This example shows how to define the mocked response for a query. The `mocks` array takes objects with specific `request`s and their associated `result`s. In this example, when the provider receives a `GET_DOG_QUERY` witht the specified variables, it returns the object under the `result` key.
 
+### addTypename
+
+You may notice the prop being passed to the MockedProvider called `addTypename`. The reason this is here is because of how Apollo Client normally works. When a request is made with Apollo Client normally, it adds a `__typename` field to every object type requested. This is to make sure that Apollo Client's cache knows how to normalize and store the response. When we're making our mocks, though, we're importing the raw queries _without typenames_ from the component files.
+
+If we don't disable the adding of typenames to queries, our imported query won't match the query actually being run by the component during our tests.
+
+> In short, If you don't have `__typename`s in your queries, pass `addTypename={false}` to your `MockedResolver`s.
+
+## Testing loading states
+
 In this example, the `Dog` component will render, but it will render in a loading state, not the final response state. This is because `MockedProvider` doesn't just return the data. It returns a promise that will resolve to that data. This allows testing of loading states as well as the final state.
 
 ```js
 it('should render loading state initially', () => {
   const component = renderer.create(
     <MockedProvider mocks={[]}>
-      <Currency />
+      <Dog />
     </MockedProvider>,
   );
 
@@ -139,27 +151,30 @@ Loading state, while important, isn't the only thing to test. To test the final 
 
 ```js
 it('should render currency conversions', async () => {
-  const currencyMock = {
-    request: { query: GET_EXCHANGE_RATES_QUERY },
-    result: { data: { rates: [{ currency: 'LOL', rate: 999 }] } },
+  const dogMock = {
+    request: {
+      query: GET_DOG_QUERY,
+      variables: { name: 'Buck' },
+    },
+    result: {
+      data: { dog: { id: 1, name: 'Buck', breed: 'poodle' } },
+    },
   };
 
   const component = renderer.create(
-    <MockedProvider mocks={[currencyMock]} addTypename={false}>
-      <Currency />
+    <MockedProvider mocks={[dogMock]} addTypename={false}>
+      <Dog name="Buck" />
     </MockedProvider>,
   );
 
   await wait(0); // wait for response
 
   const p = component.root.findByType('p');
-  expect(p.children).toContain('LOL: 999');
+  expect(p.children).toContain('Buck is a poodle');
 });
 ```
 
-Here, you can see the `await wait(0)` line. This artificially adds a delay, and allows time for that promise returned from `MockedProvider` to resolve. After that promise resolves, we can check the component to make sure it displays the correct information (in this case, `LOL: 999`).
-
-<!-- talk about addTypename -->
+Here, you can see the `await wait(0)` line. This artificially adds a delay, and allows time for that promise returned from `MockedProvider` to resolve. After that promise resolves, we can check the component to make sure it displays the correct information (in this case, "Buck is a poodle").
 
 ## Testing error states
 
@@ -167,56 +182,60 @@ Error states are one of the most important states to test, since they can make o
 
 Error states are also tested less in development. Since most developers would follow the "happy path" and not encounter these states as often, it's almost _more_ important to test these states to prevent accidental regressions.
 
-To simulate a GraphQL error, all you have to do is pass an `error` to your mock.
+To simulate a GraphQL error, all you have to do is pass an `error` to your mock instead of (or in addition to) the `result`.
 
 ```js
 it('should show error UI', async () => {
-  const currencyMock = {
-    request: { query: GET_EXCHANGE_RATES_QUERY },
+  const dogMock = {
+    request: {
+      query: GET_DOG_QUERY,
+      variables: { name: 'Buck' },
+    },
     error: new Error('aw shucks'),
   };
 
   const component = renderer.create(
-    <MockedProvider mocks={[currencyMock]} addTypename={false}>
-      <Currency />
+    <MockedProvider mocks={[dogMock]} addTypename={false}>
+      <Dog name="Buck" />
     </MockedProvider>,
   );
 
   await wait(0); // wait for response
 
   const tree = component.toJSON();
-  expect(tree.children).toContain('Error :(');
+  expect(tree.children).toContain('Error!');
 });
 ```
 
-Here, whenever your `MockProvider` receives a `GET_EXCHANGE_RATES_QUERY`, it will return a GraphQL error. This forces the component into the error state, and we can verify that it's handling the error gracefully.
+Here, whenever your `MockProvider` receives a `GET_DOG_QUERY` with matching variables, it will return a GraphQL error. This forces the component into the error state, allowing us to verify that it's handling the error gracefully.
 
 ## Testing mutation components
 
-`Mutation` components are tested very similarly to `Query` components. The only key difference is how the mutation is fired. With `Query` components, the query is fired when the component mounts. With `Mutation` components, the mutation is fired manually, usually after some user interaction like pressing a button.
+`Mutation` components are tested very similarly to `Query` components. The only key difference is how the operation is fired. With `Query` components, the query is fired when the component mounts. With `Mutation` components, the mutation is fired manually, usually after some user interaction like pressing a button.
 
 Consider this component that calls a mutation:
 
 ```js
-export const DELETE_CURRENCY_MUTATION = gql`
-  mutation deleteCurrency($name: String!) {
-    deleteCurrency(name: $name) {
-      currency
-      rate
+export const DELETE_DOG_MUTATION = gql`
+  mutation deleteDog($name: String!) {
+    deleteDog(name: $name) {
+      id
+      name
+      breed
     }
   }
 `;
 
-export default () => (
-  <Mutation mutation={DELETE_CURRENCY_MUTATION}>
+export const DeleteButton = () => (
+  <Mutation mutation={DELETE_DOG_MUTATION}>
     {(mutate, { loading, error, data }) => {
       if (loading) return <p>Loading...</p>;
-      if (error) return <p>Error :(</p>;
+      if (error) return <p>Error!</p>;
       if (data) return <p>Deleted!</p>;
 
       return (
-        <button onClick={() => mutate({ variables: { name: 'USD' } })}>
-          Click me to Delete the USD!
+        <button onClick={() => mutate({ variables: { name: 'Buck' } })}>
+          Click me to Delete Buck!
         </button>
       );
     }}
@@ -224,10 +243,10 @@ export default () => (
 );
 ```
 
-Testing an initial render for this component looks identical to testing our query component.
+Testing an initial render for this component looks identical to testing our `Query` component.
 
 ```js
-import DeleteButton, { DELETE_CURRENCY_MUTATION } from './delete-currency';
+import DeleteButton, { DELETE_DOG_MUTATION } from './delete-dog';
 
 it('should render without error', () => {
   renderer.create(
@@ -242,14 +261,14 @@ Calling the mutation is where things get interesting:
 
 ```js
 it('should render loading state initially', () => {
-  const deleteCurrency = { currency: 'USD', rate: 1.0 };
+  const deleteDog = { name: 'Buck', breed: 'Poodle', id: 1 };
   const mocks = [
     {
       request: {
-        query: DELETE_CURRENCY_MUTATION,
-        variables: { name: 'USD' },
+        query: DELETE_DOG_MUTATION,
+        variables: { name: 'Buck' },
       },
-      result: { data: { deleteCurrency } },
+      result: { data: { deleteDog } },
     },
   ];
 
@@ -276,14 +295,14 @@ For example, to test for a successful mutation, you'd just wait for the promise 
 
 ```js
 it('should delete and give visual feedback', async () => {
-  const deleteCurrency = { currency: 'USD', rate: 1.0 };
+  const deleteDog = { name: 'Buck', breed: 'Poodle', id: 1 };
   const mocks = [
     {
       request: {
-        query: DELETE_CURRENCY_MUTATION,
-        variables: { name: 'USD' },
+        query: DELETE_DOG_MUTATION,
+        variables: { name: 'Buck' },
       },
-      result: { data: { deleteCurrency } },
+      result: { data: { deleteDog } },
     },
   ];
 
@@ -304,8 +323,10 @@ it('should delete and give visual feedback', async () => {
 });
 ```
 
----
+Testing UI components isn't a simple issue, but hopefully with these tools, you can feel more confident when testing components dependent on data.
 
-## Conclusion
+For a working example showing how to test components, check out this example on CodeSandbox:
 
-Refer to the [docs](../api/react-apollo.html#MockedProvider) for more information on the API for `<MockedProvider />`.
+[![Edit React-Apollo Testing](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/40k7j708n4)
+
+<!-- Refer to the [docs](../api/react-apollo.html#MockedProvider) for more information on the API for `<MockedProvider />`. -->

--- a/docs/source/guides/testing-react-apollo.md
+++ b/docs/source/guides/testing-react-apollo.md
@@ -152,7 +152,7 @@ Loading state, while important, isn't the only thing to test. To test the final 
 ```js
 const wait = require('waait');
 
-it('should render currency conversions', async () => {
+it('should render dog', async () => {
   const dogMock = {
     request: {
       query: GET_DOG_QUERY,

--- a/docs/source/guides/testing-react-apollo.md
+++ b/docs/source/guides/testing-react-apollo.md
@@ -3,15 +3,15 @@ title: Testing React Components
 description: Have peace of mind when using react-apollo in production
 ---
 
-Running tests against code meant for production has long been a best practice. It provides additional security for the code that's already written, as well as prevents accidental regressions in the future. Components utilizing React Apollo are no exception.
+Running tests against code meant for production has long been a best practice. It provides additional security for the code that's already written, as well as prevents accidental regressions in the future. Components utilizing react-apollo are no exception.
 
-Although React Apollo has a lot going on under the hood, the library provides multiple tools for testing that simplify those abstractions, and allows complete focus on the component logic. These testing utilities have long been used to test the React Apollo library itself, so you can trust in their stability and long-term support.
+Although react-apollo has a lot going on under the hood, the library provides multiple tools for testing that simplify those abstractions, and allows complete focus on the component logic. These testing utilities have long been used to test the react-apollo library itself, so you can trust in their stability and long-term support.
 
 ## An introduction
 
-React Apollo relies on [context](https://reactjs.org/docs/context.html) in order to pass the Apollo Client instance through the React component tree. In addition, React Apollo makes network requests in order to fetch data. This behavior affects how you write tests for components that use React Apollo.
+react-apollo relies on [context](https://reactjs.org/docs/context.html) in order to pass the Apollo Client instance through the React component tree. In addition, react-apollo makes network requests in order to fetch data. This behavior affects how you write tests for components that use react-apollo.
 
-This guide will explain step-by-step how you can test your React Apollo code. The following examples will be using the [Jest](https://facebook.github.io/jest/docs/en/tutorial-react.html) testing framework, but most concepts should be reusable with other libraries. These examples aim to use as simple of a toolset as possible, so React's [test renderer](https://reactjs.org/docs/test-renderer.html) will be used in place of something like [Enzyme](https://github.com/airbnb/enzyme).
+This guide will explain step-by-step how you can test your react-apollo code. The following examples will be using the [Jest](https://facebook.github.io/jest/docs/en/tutorial-react.html) testing framework, but most concepts should be reusable with other libraries. These examples aim to use as simple of a toolset as possible, so React's [test renderer](https://reactjs.org/docs/test-renderer.html) will be used in place of something like [Enzyme](https://github.com/airbnb/enzyme) or [react-testing-library](https://github.com/kentcdodds/react-testing-library).
 
 Consider the component below, which makes a basic query, and displays its results:
 
@@ -79,7 +79,7 @@ it('renders without error', () => {
 
 To test the component in true isolation, we can mock all calls to the GraphQL endpoint. This makes the UI consistent every time tests are run, since they don't depend on any remote data.
 
-React Apollo provides the `MockedProvider` component in the `react-apollo/test-utils` library to do just that! `MockedProvider` allows us to specify the exact results that should be returned for a certain query using the `mocks` prop.
+react-apollo provides the `MockedProvider` component in the `react-apollo/test-utils` library to do just that! `MockedProvider` allows us to specify the exact results that should be returned for a certain query using the `mocks` prop.
 
 Here's an example of a test for the above `Dog` component using `MockedProvider`:
 

--- a/docs/source/guides/testing-react-components.md
+++ b/docs/source/guides/testing-react-components.md
@@ -3,15 +3,15 @@ title: Testing React Components
 description: Have peace of mind when using react-apollo in production
 ---
 
-Running tests against code meant for production has long been a best practice. It provides additional security for the code that's already written, as well as prevents accidental regressions in the future. Components utilizing react-apollo are no exception.
+Running tests against code meant for production has long been a best practice. It provides additional security for the code that's already written, and prevents accidental regressions in the future. Components utilizing `react-apollo`, the React implementation of Apollo Client, are no exception.
 
-Although react-apollo has a lot going on under the hood, the library provides multiple tools for testing that simplify those abstractions, and allows complete focus on the component logic. These testing utilities have long been used to test the react-apollo library itself, so you can trust in their stability and long-term support.
+Although `react-apollo` has a lot going on under the hood, the library provides multiple tools for testing that simplify those abstractions, and allows complete focus on the component logic. These testing utilities have long been used to test the `react-apollo` library itself, so they will be supported long-term.
 
 ## An introduction
 
-react-apollo relies on [context](https://reactjs.org/docs/context.html) in order to pass the Apollo Client instance through the React component tree. In addition, react-apollo makes network requests in order to fetch data. This behavior affects how you write tests for components that use react-apollo.
+The `react-apollo` libary relies on [context](https://reactjs.org/docs/context.html) in order to pass the `ApolloClient` instance through the React component tree. In addition, `react-apollo` makes network requests in order to fetch data. This behavior affects how tests should be written for components that use `react-apollo`.
 
-This guide will explain step-by-step how you can test your react-apollo code. The following examples will be using the [Jest](https://facebook.github.io/jest/docs/en/tutorial-react.html) testing framework, but most concepts should be reusable with other libraries. These examples aim to use as simple of a toolset as possible, so React's [test renderer](https://reactjs.org/docs/test-renderer.html) will be used in place of something like [Enzyme](https://github.com/airbnb/enzyme) or [react-testing-library](https://github.com/kentcdodds/react-testing-library).
+This guide will explain step-by-step how to test `react-apollo` code. The following examples use the [Jest](https://facebook.github.io/jest/docs/en/tutorial-react.html) testing framework, but most concepts should be reusable with other libraries. These examples aim to use as simple of a toolset as possible, so React's [test renderer](https://reactjs.org/docs/test-renderer.html) will be used in place of React-specific tools like [Enzyme](https://github.com/airbnb/enzyme) and [react-testing-library](https://github.com/kentcdodds/react-testing-library).
 
 Consider the component below, which makes a basic query, and displays its results:
 
@@ -56,13 +56,13 @@ it('should render without error', () => {
 });
 ```
 
-If we ran this test, we would get an error because Apollo Client isn't available on the context for the `Query` component to consume.
+This test would produce an error because Apollo Client isn't available on the context for the `Query` component to consume.
 
-In order to fix this we could wrap the component in an `ApolloProvider` and pass an instance of Apollo Client to the `client` prop. However, this will cause our tests to run against an actual backend which makes the tests very unpredictable for the following reasons:
+In order to fix this we could wrap the component in an `ApolloProvider` and pass an instance of Apollo Client to the `client` prop. However, this will cause the tests to run against an actual backend which makes the tests very unpredictable for the following reasons:
 
-- The server could be down
-- There may be no network connection
-- The results are not guaranteed to be the same for every query
+- The server could be down.
+- There may be no network connection.
+- The results are not guaranteed to be the same for every query.
 
 ```js
 // Not predictable
@@ -75,13 +75,13 @@ it('renders without error', () => {
 });
 ```
 
-## MockedProvider
+## `MockedProvider`
 
-To test the component in true isolation, we can mock all calls to the GraphQL endpoint. This makes the UI consistent every time tests are run, since they don't depend on any remote data.
+The `react-apollo/test-utils` module exports a `MockedProvider` component which simplifies the testing of React components by mocking calls to the GraphQL endpoint.  This allows the tests to be run in isolation and provides consistent results on every run by removing the dependence on remote data.
 
-react-apollo provides the `MockedProvider` component in the `react-apollo/test-utils` library to do just that! `MockedProvider` allows us to specify the exact results that should be returned for a certain query using the `mocks` prop.
+By using this `MockedProvider` component, it's possible to specify the exact results that should be returned for a certain query using the `mocks` prop.  
 
-Here's an example of a test for the above `Dog` component using `MockedProvider`:
+Here's an example of a test for the above `Dog` component using `MockedProvider`, which shows how to define the mocked response for `GET_DOG_QUERY`:
 
 ```js
 // dog.test.js
@@ -116,19 +116,19 @@ it('renders without error', () => {
 });
 ```
 
-This example shows how to define the mocked response for a query. The `mocks` array takes objects with specific `request`s and their associated `result`s. In this example, when the provider receives a `GET_DOG_QUERY` with the specified variables, it returns the object under the `result` key.
+The `mocks` array takes objects with specific `request`s and their associated `result`s.  When the provider receives a `GET_DOG_QUERY` with matching `variables`, it returns the corresponding object from the `result` key.
 
-### addTypename
+### `addTypename`
 
 You may notice the prop being passed to the `MockedProvider` called `addTypename`. The reason this is here is because of how Apollo Client normally works. When a request is made with Apollo Client normally, it adds a `__typename` field to every object type requested. This is to make sure that Apollo Client's cache knows how to normalize and store the response. When we're making our mocks, though, we're importing the raw queries _without typenames_ from the component files.
 
-If we don't disable the adding of typenames to queries, our imported query won't match the query actually being run by the component during our tests.
+If we don't disable the adding of typenames to queries, the imported query won't match the query actually being run by the component during our tests.
 
-> In short, If you don't have `__typename`s in your queries, pass `addTypename={false}` to your `MockedResolver`s.
+> In short, if queries are lacking `__typename`, it's important to include the `addTypename={false}` attribute to the `MockedResolver`s.
 
 ## Testing loading states
 
-In this example, the `Dog` component will render, but it will render in a loading state, not the final response state. This is because `MockedProvider` doesn't just return the data. It returns a promise that will resolve to that data. This allows testing of loading states as well as the final state.
+In this example, the `Dog` component will render, but it will render in a loading state, not the final response state. This is because `MockedProvider` doesn't just return the data but instead returns a `Promise` that will resolve to that data.  By using a `Promise` it enables testing of the loading state in addition to the final state:
 
 ```js
 it('should render loading state initially', () => {
@@ -143,7 +143,7 @@ it('should render loading state initially', () => {
 });
 ```
 
-This example shows how to (very basically) test loading state of a component. Here, all we're checking is that the children of the component contain the text `Loading...`. In real apps, this test would probably be more complicated, but the testing logic would be the same.
+This shows a basic example test that tests the loading state of a component by checking that the children of the component contain the text `Loading...`. In an actual application, this test would probably be more complicated, but the testing logic would be the same.
 
 ## Testing final state
 
@@ -176,17 +176,17 @@ it('should render dog', async () => {
 });
 ```
 
-Here, you can see the `await wait(0)` line. This is a util function from a npm package called `waait`.This artificially adds a delay until the next tick, and allows time for that promise returned from `MockedProvider` to resolve. After that promise resolves, we can check the component to make sure it displays the correct information (in this case, "Buck is a poodle").
+Here, you can see the `await wait(0)` line. This is a utility function from the [`waait`](https://npm.im/waait) npm package. It delays until the next "tick" of the event loop, and allows time for that `Promise` returned from `MockedProvider` to be fulfilled. After that `Promise` resolves (or rejects), the component can be checked to ensure it displays the correct information — in this case, "Buck is a poodle".
 
-In some cases with complex UI, heavy calculations, or delays added into the render logic of a component, the `wait(0)` will not be long enough. In these cases, you could either increase the wait time or use a package like [wait-for-expect](https://github.com/TheBrainFamily/wait-for-expect) to wait until the render has happened. The risk of using a package like this everywhere by default is that _every_ test could take up to 5 seconds (or longer if you have increased the default timeout) to execute.
+For more complex UI with heavy calculations, or delays added into its render logic, the `wait(0)` will not be long enough. In these cases, you could either increase the wait time or use a package like [`wait-for-expect`](https://npm.im/wait-for-expect) to delay until the render has happened. The risk of using a package like this everywhere by default is that _every_ test could take up to five seconds to execute (or longer if the default timeout has been increased).
 
 ## Testing error states
 
-Error states are one of the most important states to test, since they can make or break the experience a user has when interacting with the app.
+Since they can make or break the experience a user has when interacting with the app, error states are one of the most important states to test, but are often less tested in development.
 
-Error states are also tested less in development. Since most developers would follow the "happy path" and not encounter these states as often, it's almost _more_ important to test these states to prevent accidental regressions.
+Since most developers would follow the "happy path" and not encounter these states as often, it's almost _more_ important to test these states to prevent accidental regressions.
 
-To simulate a GraphQL error, all you have to do is pass an `error` to your mock instead of (or in addition to) the `result`.
+To simulate a GraphQL error, an `error` property can be included on the mock, in place of or in addition to the `result`.
 
 ```js
 it('should show error UI', async () => {
@@ -211,11 +211,11 @@ it('should show error UI', async () => {
 });
 ```
 
-Here, whenever your `MockProvider` receives a `GET_DOG_QUERY` with matching variables, it will return a GraphQL error. This forces the component into the error state, allowing us to verify that it's handling the error gracefully.
+Here, whenever the `MockedProvider` receives a `GET_DOG_QUERY` with matching `variables`, it will return the error assigned to the `error` property in the mock. This forces the component into the error state, allowing verification that it's being handled gracefully.
 
 ## Testing mutation components
 
-`Mutation` components are tested very similarly to `Query` components. The only key difference is how the operation is fired. With `Query` components, the query is fired when the component mounts. With `Mutation` components, the mutation is fired manually, usually after some user interaction like pressing a button.
+`Mutation` components are tested very similarly to `Query` components. The only key difference is how the operation is fired. On a `Query` component, the query is fired when the component _mounts_, whereas with `Mutation` components, the mutation is fired manually, usually after some user interaction like pressing a button.
 
 Consider this component that calls a mutation:
 
@@ -291,13 +291,13 @@ it('should render loading state initially', () => {
 });
 ```
 
-This example looks very similar to the `Query` component. The difference comes after the render. Since this component relies on a button to be clicked to fire a mutation, we first use the renderer's API to find that button.
+This example looks very similar to the `Query` component, but the difference comes after the rendering is completed. Since this component relies on a button to be clicked to fire a mutation, the renderer's API is used to find the button.
 
-After we find the button, we can manually call the `onClick` prop to that button, simulating a user clicking the button. This click fires off the mutation, and then the rest is tested identically to the `Query` component.
+After a reference to the button has been obtained, a "click" on the button can be simulated by calling its `onClick` handler. This will fire off the mutation, and then the rest will be tested identically to the `Query` component.
 
-> Note: Other test utilities like [Enzyme](https://github.com/airbnb/enzyme) and [react-testing-library](https://github.com/kentcdodds/react-testing-library) have built-in tools for finding elements and simulating events, but the concept is the same: find the button, and simulate a click on it.
+> Note: Other test utilities like [Enzyme](https://github.com/airbnb/enzyme) and [react-testing-library](https://github.com/kentcdodds/react-testing-library) have built-in tools for finding elements and simulating events, but the concept is the same: find the button and simulate a click on it.
 
-To test for a successful mutation after simulating the click, you'd just wait for the promise to resolve from `MockedProvider` and check for any confirmation message in your UI, just like the `Query` component:
+To test for a successful mutation after simulating the click, the fulfilled `Promise` from `MockedProvider` can be checked for the appropriate confirmation message, just like the `Query` component:
 
 ```js
 it('should delete and give visual feedback', async () => {
@@ -331,7 +331,7 @@ it('should delete and give visual feedback', async () => {
 
 For the sake of simplicity, the error case for mutations hasn't been shown here, but testing `Mutation` errors is exactly the same as testing `Query` errors: just add an `error` to the mock, fire the mutation, and check the UI for error messages.
 
-Testing UI components isn't a simple issue, but hopefully with these tools, you can feel more confident when testing components dependent on data.
+Testing UI components isn't a simple issue, but hopefully these tools will create confidence when testing components that are dependent on data.
 
 For a working example showing how to test components, check out this project on CodeSandbox:
 

--- a/docs/source/guides/testing-react-components.md
+++ b/docs/source/guides/testing-react-components.md
@@ -124,7 +124,7 @@ You may notice the prop being passed to the `MockedProvider` called `addTypename
 
 If we don't disable the adding of typenames to queries, the imported query won't match the query actually being run by the component during our tests.
 
-> In short, if queries are lacking `__typename`, it's important to include the `addTypename={false}` attribute to the `MockedResolver`s.
+> In short, if queries are lacking `__typename`, it's important to pass the `addTypename={false}` prop to the `MockedProvider`s.
 
 ## Testing loading states
 


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

# Testing React Apollo 

This is a guide specifically for testing React Apollo. Based off of @excitement-engineer's (great) original work [in this PR](https://github.com/apollographql/apollo-client/pull/3309).

**A few notes:**
- I'm keeping this separate from server testing, since combined I think they'll be too long. **I'm open to discussion on this, though**.
- I added the guide here rather than React Apollo's docs, since I feel like we have a good set of `guides` here, and would hate for this to be missing. I also feel like the view logic may transfer to other UI integrations, but I don't have a lot of insight into that.
- I went with using `wait(0)` instead of refactoring and counting renders like some other exmples do, for simplicity. I wanted to lower the barrier of entry for testing as much as possible.
- I used `react-test-renderer` instead of Enzyme or anything else, just to keep the toolset as simple as possible.