### PR TITLE
docs: Update blog URLs to reference blog.apollographql.com.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 This is the main repository for discussion and coordination - the code will live elsewhere. Follow this repository for updates on the project!
 
 - Check out the [homepage](http://www.apollographql.com/)
-- Stay up to date by reading our [posts on Medium](https://dev-blog.apollodata.com)
-- [Join us on Slack!](http://www.apollodata.com/#slack)
+- Stay up to date by reading our [posts on Medium](https://blog.apollographql.com/)
+- [Join us on Slack!](http://www.apollographql.com/slack)

--- a/docs/source/fundamentals/benefits.md
+++ b/docs/source/fundamentals/benefits.md
@@ -41,7 +41,7 @@ const client = new ApolloClient({
 });
 ```
 
-Teams who have switched to Apollo Client have reported [deleting thousands of lines of state management code](https://dev-blog.apollodata.com/reducing-our-redux-code-with-react-apollo-5091b9de9c2a) and lots of complexity from their application. Since Apollo Client supports managing both local and remote data, you can use the Apollo cache as a single source of truth for all global state in your application.
+Teams who have switched to Apollo Client have reported [deleting thousands of lines of state management code](https://blog.apollographql.com/reducing-our-redux-code-with-react-apollo-5091b9de9c2a) and lots of complexity from their application. Since Apollo Client supports managing both local and remote data, you can use the Apollo cache as a single source of truth for all global state in your application.
 
 <h3 id="modern-tooling">Modern tooling</h3>
 
@@ -140,4 +140,4 @@ GET /api/dogs/images
 GET /api/dogs/activities
 ```
 
-With GraphQL, each query represents a single round trip from the client to server. If you'd like to reduce round trips even further, you can implement [query batching](https://www.apollographql.com/docs/engine/query-batching.html) to batch multiple queries into a single request. 
+With GraphQL, each query represents a single round trip from the client to server. If you'd like to reduce round trips even further, you can implement [query batching](https://www.apollographql.com/docs/engine/query-batching.html) to batch multiple queries into a single request.

--- a/docs/source/fundamentals/platform.md
+++ b/docs/source/fundamentals/platform.md
@@ -37,7 +37,7 @@ In addition to our own experience, we have received extensive feedback, contribu
 
 - [**The New York Times**](https://open.nytimes.com/the-new-york-times-now-on-apollo-b9a78a5038c): Learn how The New York Times switched from Relay to Apollo & implemented features in their app such as SSR and persisted queries
 - [**Airbnb**](https://medium.com/airbnb-engineering/reconciling-graphql-and-thrift-at-airbnb-a97e8d290712): Airbnb is betting big on the Apollo platform to power the data layer for their microservices
-- [**Express**](https://dev-blog.apollodata.com/changing-the-architecture-of-express-com-23c950d43323): Easy-to-use pagination with Apollo helped improve the Express eCommerce team's key product pages
-- [**Major League Soccer**](https://dev-blog.apollodata.com/reducing-our-redux-code-with-react-apollo-5091b9de9c2a): MLS' switch from Redux to Apollo for state management enabled them to delete nearly all of their Redux code
-- [**Expo**](https://dev-blog.apollodata.com/using-graphql-apollo-at-expo-4c1f21f0f115): Developing their React Native app with Apollo allowed the Expo engineers to focus on improving their product instead of writing data fetching logic
+- [**Express**](https://blog.apollographql.com/changing-the-architecture-of-express-com-23c950d43323): Easy-to-use pagination with Apollo helped improve the Express eCommerce team's key product pages
+- [**Major League Soccer**](https://blog.apollographql.com/reducing-our-redux-code-with-react-apollo-5091b9de9c2a): MLS' switch from Redux to Apollo for state management enabled them to delete nearly all of their Redux code
+- [**Expo**](https://blog.apollographql.com/using-graphql-apollo-at-expo-4c1f21f0f115): Developing their React Native app with Apollo allowed the Expo engineers to focus on improving their product instead of writing data fetching logic
 - [**KLM**](https://youtu.be/T2njjXHdKqw): Learn how the KLM team scaled their Angular app with GraphQL and Apollo

--- a/docs/source/guides/access-control.md
+++ b/docs/source/guides/access-control.md
@@ -39,7 +39,7 @@ server.listen().then(({ url }) => {
 });
 ```
 
-So what’s happening here, exactly? This block of code is setting up a new GraphQL server, using the beta of Apollo Server 2.0. This new version of Apollo Server simplifies the API for creating new servers, and has some more intelligent defaults. You can read more about it [here](https://dev-blog.apollodata.com/apollo-server-2-0-30c9bbb4ab5e)!
+So what’s happening here, exactly? This block of code is setting up a new GraphQL server, using the beta of Apollo Server 2.0. This new version of Apollo Server simplifies the API for creating new servers, and has some more intelligent defaults. You can read more about it [here](https://blog.apollographql.com/apollo-server-2-0-30c9bbb4ab5e)!
 
 In this constructor, we pass type definitions and resolvers to the constructor as well as a function to build our `context` object. The `context` object is one that gets passed to every single resolver at every level, so we can access it anywhere in our schema code. It’s where we can store things like data fetchers, database connections, and (conveniently) information about the user making the request.
 
@@ -222,7 +222,7 @@ const typeDefs = `
 
 The `@auth` directive can be called directly on the type, or on the fields if you want to limit access to specific fields as shown in the example above. The logic behind authorization is hidden away in the directive implementation. 
 
-One way of implementing the `@auth` directive is via the [SchemaDirectiveVisitor](https://www.apollographql.com/docs/graphql-tools/schema-directives.html) class from [graphql-tools](https://github.com/apollographql/graphql-tools). Ben Newman covered creating a sample `@deprecated` and `@rest` directive in this [excellent article](https://dev-blog.apollodata.com/reusable-graphql-schema-directives-131fb3a177d1). You can draw inspiration from these examples.
+One way of implementing the `@auth` directive is via the [SchemaDirectiveVisitor](https://www.apollographql.com/docs/graphql-tools/schema-directives.html) class from [graphql-tools](https://github.com/apollographql/graphql-tools). Ben Newman covered creating a sample `@deprecated` and `@rest` directive in this [excellent article](https://blog.apollographql.com/reusable-graphql-schema-directives-131fb3a177d1). You can draw inspiration from these examples.
 
 
 <h2 id="rest-auth">Authorization outside of GraphQL</h2>

--- a/docs/source/guides/security.md
+++ b/docs/source/guides/security.md
@@ -78,4 +78,4 @@ We suggest implementing complexity limits using community-provided packages like
 
 <h2 id="resources">Additional resources</h2>
 
-> For additional information on securing a GraphQL server deployment, check out [Securing your GraphQL API from malicious queries](https://dev-blog.apollodata.com/securing-your-graphql-api-from-malicious-queries-16130a324a6b) by Spectrum co-founder, Max Stoiber.
+> For additional information on securing a GraphQL server deployment, check out [Securing your GraphQL API from malicious queries](https://blog.apollographql.com/securing-your-graphql-api-from-malicious-queries-16130a324a6b) by Spectrum co-founder, Max Stoiber.


### PR DESCRIPTION
This updates all blog URLs in the documentation to use blog.apollographql.com
as the domain, rather than dev-blog.apollodata.com.