### PR TITLE
Update non-breaking change use case

### DIFF
--- a/docs/source/guides/versioning.md
+++ b/docs/source/guides/versioning.md
@@ -98,7 +98,7 @@ type Query {
   getUsers(ids: [ID!]!): [User]!
 
   # what we want to end up with
-  getUsers(ids: [ID!], groupId: ID!): [User]!
+  getUsers(ids: [ID!]!, groupId: ID!): [User]!
 }
 ```
 


### PR DESCRIPTION
The way it is written, there are 2 changes in the example, which could confuse users.  Instead, we keep the signature of the first param the same.

- [x] docs