### PR TITLE
Change `authentication` to `authorization`

### DIFF
--- a/docs/source/guides/access-control.md
+++ b/docs/source/guides/access-control.md
@@ -62,7 +62,7 @@ To do this kind of authorization, we can just modify the context function.
 ```js
 context: ({ req }) => {
  // get the user token from the headers
- const token = req.headers.authentication || '';
+ const token = req.headers.authorization || '';
 
  // try to retrieve a user with the token
  const user = getUser(token);


### PR DESCRIPTION
In the first example, the author used `req.headers.authorization` to store/retrieve the authentication token, but in the second code snippet, `req.headers.authentication` was used


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [X] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->