### PR TITLE
Update graphql-glossary.md

### DIFF
--- a/docs/source/resources/graphql-glossary.md
+++ b/docs/source/resources/graphql-glossary.md
@@ -67,7 +67,7 @@ query NewsFeed {
 ```
 
 <h2 id="directive">Directive</h2>
-<p>A declaration prefixed with an `@` character that encapsulates programming logic for query execution on the client or server. There are built-in such as `@skip`, `@include` and [custom directives](https://www.apollographql.com/docs/graphql-tools/schema-directives.html). It can be used for features such as authentication, incremental data loading, etc.</p>
+<p>A declaration prefixed with an `@` character that encapsulates programming logic for query execution on the client or server. There are built-in directives such as `@skip` or `@include`, and [custom directives](https://www.apollographql.com/docs/graphql-tools/schema-directives.html). Directives can be used for features such as authentication, incremental data loading, etc.</p>
 
 ```js
 type User @auth {


### PR DESCRIPTION
- [ ] feature
- [ ] blocking
- [x] docs

Suggesting an edit for clarity. Although now there is some word repetition, it's much clearer that built-in and custom directives are different, and what "it" referred to. I think repetition in this case improves comprehension. 