### PR TITLE
Explain how to mock GraphQL errors

### DIFF
--- a/docs/source/guides/testing-react-components.md
+++ b/docs/source/guides/testing-react-components.md
@@ -186,7 +186,7 @@ Since they can make or break the experience a user has when interacting with the
 
 Since most developers would follow the "happy path" and not encounter these states as often, it's almost _more_ important to test these states to prevent accidental regressions.
 
-To simulate a GraphQL error, an `error` property can be included on the mock, in place of or in addition to the `result`.
+To simulate a network error, an `error` property can be included on the mock, in place of or in addition to the `result`.
 
 ```js
 it('should show error UI', async () => {
@@ -212,6 +212,17 @@ it('should show error UI', async () => {
 ```
 
 Here, whenever the `MockedProvider` receives a `GET_DOG_QUERY` with matching `variables`, it will return the error assigned to the `error` property in the mock. This forces the component into the error state, allowing verification that it's being handled gracefully.
+
+To simulate GraphQL errors, simply define `errors` along with any data in your result.
+
+```js
+const dogMock = {
+  // ...
+  result: {
+    errors: [{ message: "Error!" }],
+  },
+};
+```
 
 ## Testing mutation components
 


### PR DESCRIPTION
I was testing my application and had to look in a specific part of documentation to understand that `graphQLErrors` are just taken from the result. This might help a few people like in https://github.com/apollographql/react-apollo/issues/1127.

Using `error` key on the mock will only result in a `networkError` define. This fix explains how to define GraphQL errors which might not be explicit when a beginner is not used to it.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->