### PR TITLE
Run your graph in production

### DIFF
--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -93,7 +93,9 @@ Set the `ENGINE_API_KEY` environment variable via the command line:
 $ ENGINE_API_KEY=YOUR_API_KEY npm start
 ```
 
-Once this is done, you can now have access to all the features that Apollo Engine provides:
+Once this is done, run a query in GraphQL Playground, and log in to your Engine account to monitor the graph's performance.
+
+Apollo Engine provides all of the following features highlighted below:
 
 * **Schema Explorer:** With Engine's powerful schema registry, you can quickly explore all the types and fields in your schema with usage statistics on each field. This metric makes you understand the cost of a field. How expensive is a field? Is a certain field in so much demand?
 * **Schema history:** Apollo Engine’s schema history allows developers to confidently iterate a graph's schema by validating the new schema against field-level usage data from the previous schema. This empowers developers to avoid breaking changes by providing insights into which clients will be broken by a new schema.

--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -100,3 +100,5 @@ Once this is done, you can now have access to all the features that Apollo Engin
 * **Performance Analytics:** Fine-grained insights into every field, resolvers and operations of your graph's execution.
 * **Query tracing:**  The _Trace view_ in the Engine UI allows you to look at a detailed breakdown of the execution of one query, with timing for every resolver.
 * **Performance alerts:** You can configure notifications to be sent to various channels like Slack, and PagerDuty. Apollo Engine can be set to send alerts when a request rate, duration or error rate exceeds a certain threshold. You can effectively monitor everything going on in your graph's service.
+
+The [Engine](https://www.apollographql.com/docs/engine/) guide provides detailed instructions on how Apollo Engine works and the setup for any type for performance or usage analytics.

--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -14,17 +14,17 @@ You need the following before deployment:
 
 Now looks for a `start` script in the `package.json` file to start the app. Once the script is present, Now will be able to start the app.
 
-Go ahead and run the `now` command from the root directory of the app.
+Go ahead and run the `now` command from the root directory of the app to deploy our app to Now.
 
 ```bash
 $ now
 ```
 
-The `now` command immediately deploys your graph API to the cloud and returns the hosted URL. The returned URL comes in this format: `<NOW_APP_NAME>.now.sh`.
+The `now` command immediately deploys our graph API to the cloud and returns the hosted URL. The returned URL comes in this format: `<NOW_APP_NAME>.now.sh`.
 
-You can now query your graph service at `<NOW_APP_NAME>.now.sh/graphql`.
+You can now query the graph service at `<NOW_APP_NAME>.now.sh/graphql`.
 
-Now also supports direct deployment from a GitHub repository. If your graph API is publicly available on GitHub, you can deploy it via the `now` command like so:
+**Note:** Now also supports direct deployment from a GitHub repository. If your graph API is publicly available on GitHub, you can deploy it via the `now` command like so:
 
 ```bash
 now <github-username>/<repository-name>
@@ -36,7 +36,7 @@ Safely evolving your schema overtime requires a lot of developer efforts in ensu
 
 [Apollo Engine](https://engine.apollographql.com), provides deep insights into your graph layer that enables you to understand, optimize, and control your graph service in production with confidence.
 
-Once you publish your schema to Apollo Engine, it becomes the basis for comparison for validating future schemas and avoiding breaking changes. Therefore, a schema should be re-published to Apollo Engine each time a new schema is deployed.
+Once we publish our schema to Apollo Engine, it becomes the basis for comparison for validating future schemas and avoiding breaking changes. Therefore, a schema should be re-published to Apollo Engine each time a new schema is deployed.
 
 Go ahead and install the `apollo` CLI via npm:
 
@@ -44,17 +44,19 @@ Go ahead and install the `apollo` CLI via npm:
 npm install --global apollo
 ```
 
-To publish a schema, start your GraphQL server and run the command below:
+To publish our schema to Apollo Engine, we need an API key.
+
+An API key can be obtained from a graph service’s _Settings_ menu within the [Apollo Engine dashboard](https://engine.apollographql.com).
+
+Now start your GraphQL server and run the command below:
 
 ```bash
 apollo schema:publish --key="<API_KEY>" --endpoint="https://<now_app_name>.now.sh/graphql"
 ```
 
-**Note:** An API key can be obtained from a graph service’s _Settings_ menu within the [Apollo Engine dashboard](https://engine.apollographql.com).
-
 The `--endpoint` flag should be set to the URL of a running GraphQL server.
 
-Every time your schema is updated, run the `apollo schema:publish` command so that Apollo Engine can provide a history of schema changes. This allows everyone on your team to know when new types and fields are added or removed. Apollo Engine also provides a reference to the commits that introduced changes to the schema.
+Every time the schema is updated, run the `apollo schema:publish` command so that Apollo Engine can provide a history of schema changes. This allows everyone on your team to know when new types and fields are added or removed. Apollo Engine also provides a reference to the commits that introduced changes to the schema.
 
 To check the difference between the current schema and a newly published schema version, you can run the command below:
 
@@ -72,9 +74,7 @@ Apollo Engine identifies three categories of changes and report them to the deve
 
 You need a bird's-eye view of your graph's API. Understanding how your schema fields, and queries operates within your graph service opens you to a whole new world of effective optimization and scaling!
 
-In order to get access to your graph's performance metrics, hook up Apollo Server with Engine.
-
-First, get an API key from [Engine](https://engine.apollographql.com). Now, connect to Engine by passing the API key to the Apollo Server constructor:
+In order to get access to your graph's performance metrics, hook up Apollo Server with Engine. Connect to Engine by passing the API key to the Apollo Server constructor:
 
 _src/index.js_
 
@@ -100,7 +100,6 @@ Apollo Engine provides all of the following features highlighted below:
 * **Schema Explorer:** With Engine's powerful schema registry, you can quickly explore all the types and fields in your schema with usage statistics on each field. This metric makes you understand the cost of a field. How expensive is a field? Is a certain field in so much demand?
 * **Schema history:** Apollo Engine’s schema history allows developers to confidently iterate a graph's schema by validating the new schema against field-level usage data from the previous schema. This empowers developers to avoid breaking changes by providing insights into which clients will be broken by a new schema.
 * **Performance Analytics:** Fine-grained insights into every field, resolvers and operations of your graph's execution.
-* **Query tracing:**  The _Trace view_ in the Engine UI allows you to look at a detailed breakdown of the execution of one query, with timing for every resolver.
 * **Performance alerts:** You can configure notifications to be sent to various channels like Slack, and PagerDuty. Apollo Engine can be set to send alerts when a request rate, duration or error rate exceeds a certain threshold. You can effectively monitor everything going on in your graph's service.
 
 The [Engine](https://www.apollographql.com/docs/engine/) guide provides detailed instructions on how Apollo Engine works and the setup for any type for performance or usage analytics.

--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -1,105 +1,61 @@
 ---
 title: "4. Run your graph in production"
-description: Start here for the Apollo fullstack tutorial
+description: Learn about deployment and essential developer tooling
 ---
+
+Great job for making it this far! We've already learned how to build a graph API with Apollo, connect it to REST and SQL data sources, and send GraphQL queries. Now that we've completed building our graph, it's finally time to deploy it! 🎉
+
+An Apollo graph API can be deployed to any cloud service, such as Heroku, AWS Lambda, or Netlify. In this tutorial, we'll deploy our graph API to [Zeit Now](https://zeit.co/now). You will need to create a [Now account](https://zeit.co/now) in order to follow these steps. If you haven't already created an [Apollo Engine](https://engine.apollographql.com/) account, you will need to sign up for one. 
+
+<h2 id="engine">Publish your schema to Engine</h2>
+
+Before we deploy your app, we need to publish our schema to the Apollo Engine cloud service in order to power developer tooling like VSCode and keep track of schema changes. Just like npm is a registry for JavaScript packages, Apollo Engine contains a schema registry that makes it simple to pull the most recent schema from the cloud.
+
+In a production application, you should set up this publishing script as part of your CI workflow. For now, we will run a script in our terminal that uses the Apollo CLI to publish our schema to Engine.
+
+<h3 id="api-key">Get an Engine API key</h3>
+
+First, we need an Apollo Engine API key. Navigate to [Apollo Engine](https://engine.apollographql.com/), login, and click on New Service at the top. The prompt will instruct you to name your service. When you're finished, click Create Service. You'll see a key appear prefixed by `service:`. Copy that key so we can save it as an environment variable.
+
+Let's save our key as an environment variable. It's important to make sure we don't check our Engine API key into version control. Go ahead and make a copy of the `.env.example` file located in `server/` and call it `.env`. Add your Engine API key that you copied from the previous step to the file:
+
+```
+ENGINE_API_KEY=service:your-key-here
+```
+
+Our key is now stored under the environment variable `ENGINE_API_KEY`.
+
+<h3 id="publish">Check and publish with the Apollo CLI</h3>
+
+It's time to publish our schema to Engine! First, start your server in one terminal window by running `npm start`. In another terminal window, run:
+
+```bash
+npx apollo schema:check && npx apollo schema:publish
+```
+
+This command checks your schema to ensure there are no breaking changes and publishes your schema to the Apollo registry. Once your schema is uploaded, you should be able to see your schema in the [Apollo Engine](https://engine.apollographql.com/) explorer. In future steps, we will pull down our schema from Engine in order to power the Apollo VSCode extension.
+
+<h3 id="benefits">What are the benefits of Engine?</h3>
+
+Publishing your schema to Apollo Engine unlocks many features necessary for running a graph API in production. Some of these features include:
+
+* **Schema explorer:** With Engine's powerful schema registry, you can quickly explore all the types and fields in your schema with usage statistics on each field. This metric makes you understand the cost of a field. How expensive is a field? Is a certain field in so much demand?
+* **Schema history:** Apollo Engine’s schema history allows developers to confidently iterate a graph's schema by validating the new schema against field-level usage data from the previous schema. This empowers developers to avoid breaking changes by providing insights into which clients will be broken by a new schema.
+* **Performance analytics:** Fine-grained insights into every field, resolvers and operations of your graph's execution
+* **Performance alerts:** You can configure notifications to be sent to various channels like Slack, and PagerDuty. Apollo Engine can be set to send alerts when a request rate, duration or error rate exceeds a certain threshold.
+
+We also want to be transparent that the features we just described, such as field metrics, performance alerts, and validating schema changes against recent operations, are only available on a paid plan. Individual developers just getting started with GraphQL probably don't need these features, but they become incredibly valuable as you're working on a team. Additionally, layering these paid features on top of our free developer tools like Apollo VSCode makes them more intelligent over time. 
+
+We're committed to helping you succeed building and running an Apollo graph API. This is why features such as publishing and downloading schemas from the registry, our open source offerings like Apollo Client and Apollo Server, and certain developer tools like Apollo VSCode and Apollo DevTools will always be free forever.
 
 <h2 id="deploy">Deploy your graph API</h2>
 
-There are several services you can deploy your graph API to such as Heroku, Amazon Lambda, Netlify and Zeit's Now.  We'll deploy our graph API to Zeit's **Now**. Now is a service by Zeit that allows the deployment of an instance of Apollo Server, quickly providing a functional GraphQL endpoint.
-
-You need the following before deployment:
-
-* A [Now](https://zeit.co/now) account.
-* The [Now CLI](https://zeit.co/download#now-cli).
-
-Now looks for a `start` script in the `package.json` file to start the app. Once the script is present, Now will be able to start the app.
-
-Go ahead and run the `now` command from the root directory of the app to deploy our app to Now.
+To deploy our app to Now, run the `now` command from the `server` directory of the app. The command may prompt you to login if you haven't already.
 
 ```bash
-$ now
+$ npx now
 ```
 
-The `now` command immediately deploys our graph API to the cloud and returns the hosted URL. The returned URL comes in this format: `<NOW_APP_NAME>.now.sh`.
+The `now` command immediately deploys our graph API to the cloud and returns the hosted URL. Make sure you either copy the URL or run `npx now ls` in your terminal to retrieve the URL, since we'll need it in the following section when we build our client.
 
-You can now query the graph service at `<NOW_APP_NAME>.now.sh/graphql`.
-
-**Note:** Now also supports direct deployment from a GitHub repository. If your graph API is publicly available on GitHub, you can deploy it via the `now` command like so:
-
-```bash
-now <github-username>/<repository-name>
-```
-
-<h2 id="publish-schema">Publish your schema to Engine</h2>
-
-Safely evolving your schema overtime requires a lot of developer efforts in ensuring that clients consuming your API do not break as a result of schema changes. The Apollo platform provides the ability to publish your schema to Engine via the [Apollo CLI](https://npm.im/apollo).
-
-[Apollo Engine](https://engine.apollographql.com), provides deep insights into your graph layer that enables you to understand, optimize, and control your graph service in production with confidence.
-
-Once we publish our schema to Apollo Engine, it becomes the basis for comparison for validating future schemas and avoiding breaking changes. Therefore, a schema should be re-published to Apollo Engine each time a new schema is deployed.
-
-Go ahead and install the `apollo` CLI via npm:
-
-```bash
-npm install --global apollo
-```
-
-To publish our schema to Apollo Engine, we need an API key.
-
-An API key can be obtained from a graph service’s _Settings_ menu within the [Apollo Engine dashboard](https://engine.apollographql.com).
-
-Now start your GraphQL server and run the command below:
-
-```bash
-apollo schema:publish --key="<API_KEY>" --endpoint="https://<now_app_name>.now.sh/graphql"
-```
-
-The `--endpoint` flag should be set to the URL of a running GraphQL server.
-
-Every time the schema is updated, run the `apollo schema:publish` command so that Apollo Engine can provide a history of schema changes. This allows everyone on your team to know when new types and fields are added or removed. Apollo Engine also provides a reference to the commits that introduced changes to the schema.
-
-To check the difference between the current schema and a newly published schema version, you can run the command below:
-
-```bash
-apollo schema:check --key="<API_KEY>" --endpoint="https://<now_app_name>.now.sh/graphql"
-```
-
-Apollo Engine identifies three categories of changes and report them to the developer on the command line or within a GitHub pull-request:
-
-* **Failure:** Either the schema is invalid or the changes will break current clients.
-* **Warning:** There are potential problems that may come from this change, but no clients are immediately impacted.
-* **Notice:** This change is safe and will not break current clients.
-
-<h2 id="monitoring">Monitor your graph's performance</h2>
-
-You need a bird's-eye view of your graph's API. Understanding how your schema fields, and queries operates within your graph service opens you to a whole new world of effective optimization and scaling!
-
-In order to get access to your graph's performance metrics, hook up Apollo Server with Engine. Connect to Engine by passing the API key to the Apollo Server constructor:
-
-_src/index.js_
-
-```js
-// Set up Apollo Server
-const server = new ApolloServer({
-  ...
-  ...
-  engine: process.env.ENGINE_API_KEY ? { apiKey: process.env.ENGINE_API_KEY } : undefined,
-});
-```
-
-Set the `ENGINE_API_KEY` environment variable via the command line:
-
-```bash
-$ ENGINE_API_KEY=YOUR_API_KEY npm start
-```
-
-Once this is done, run a query in GraphQL Playground, and log in to your Engine account to monitor the graph's performance.
-
-Apollo Engine provides all of the following features highlighted below:
-
-* **Schema Explorer:** With Engine's powerful schema registry, you can quickly explore all the types and fields in your schema with usage statistics on each field. This metric makes you understand the cost of a field. How expensive is a field? Is a certain field in so much demand?
-* **Schema history:** Apollo Engine’s schema history allows developers to confidently iterate a graph's schema by validating the new schema against field-level usage data from the previous schema. This empowers developers to avoid breaking changes by providing insights into which clients will be broken by a new schema.
-* **Performance Analytics:** Fine-grained insights into every field, resolvers and operations of your graph's execution.
-* **Performance alerts:** You can configure notifications to be sent to various channels like Slack, and PagerDuty. Apollo Engine can be set to send alerts when a request rate, duration or error rate exceeds a certain threshold. You can effectively monitor everything going on in your graph's service.
-
-The [Engine](https://www.apollographql.com/docs/engine/) guide provides detailed instructions on how Apollo Engine works and the setup for any type for performance or usage analytics.
+Congrats on deploying your first Apollo graph API! 🚀 Let's move on to the second half of the tutorial where we connect the API we just built to a React app.

--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -3,8 +3,100 @@ title: "4. Run your graph in production"
 description: Start here for the Apollo fullstack tutorial
 ---
 
-<h2 id="publish-schema">Publish your schema to Engine</h2>
-
 <h2 id="deploy">Deploy your graph API</h2>
 
+There are several services you can deploy your graph API to such as Heroku, Amazon Lambda, Netlify and Zeit's Now.  We'll deploy our graph API to Zeit's **Now**. Now is a service by Zeit that allows the deployment of an instance of Apollo Server, quickly providing a functional GraphQL endpoint.
+
+You need the following before deployment:
+
+* A [Now](https://zeit.co/now) account.
+* The [Now CLI](https://zeit.co/download#now-cli).
+
+Now looks for a `start` script in the `package.json` file to start the app. Once the script is present, Now will be able to start the app.
+
+Go ahead and run the `now` command from the root directory of the app.
+
+```bash
+$ now
+```
+
+The `now` command immediately deploys your graph API to the cloud and returns the hosted URL. The returned URL comes in this format: `<NOW_APP_NAME>.now.sh`.
+
+You can now query your graph service at `<NOW_APP_NAME>.now.sh/graphql`.
+
+Now also supports direct deployment from a GitHub repository. If your graph API is publicly available on GitHub, you can deploy it via the `now` command like so:
+
+```bash
+now <github-username>/<repository-name>
+```
+
+<h2 id="publish-schema">Publish your schema to Engine</h2>
+
+Safely evolving your schema overtime requires a lot of developer efforts in ensuring that clients consuming your API do not break as a result of schema changes. The Apollo platform provides the ability to publish your schema to Engine via the [Apollo CLI](https://npm.im/apollo).
+
+[Apollo Engine](https://engine.apollographql.com), provides deep insights into your graph layer that enables you to understand, optimize, and control your graph service in production with confidence.
+
+Once you publish your schema to Apollo Engine, it becomes the basis for comparison for validating future schemas and avoiding breaking changes. Therefore, a schema should be re-published to Apollo Engine each time a new schema is deployed.
+
+Go ahead and install the `apollo` CLI via npm:
+
+```bash
+npm install --global apollo
+```
+
+To publish a schema, start your GraphQL server and run the command below:
+
+```bash
+apollo schema:publish --key="<API_KEY>" --endpoint="https://<now_app_name>.now.sh/graphql"
+```
+
+**Note:** An API key can be obtained from a graph service’s _Settings_ menu within the [Apollo Engine dashboard](https://engine.apollographql.com).
+
+The `--endpoint` flag should be set to the URL of a running GraphQL server.
+
+Every time your schema is updated, run the `apollo schema:publish` command so that Apollo Engine can provide a history of schema changes. This allows everyone on your team to know when new types and fields are added or removed. Apollo Engine also provides a reference to the commits that introduced changes to the schema.
+
+To check the difference between the current schema and a newly published schema version, you can run the command below:
+
+```bash
+apollo schema:check --key="<API_KEY>" --endpoint="https://<now_app_name>.now.sh/graphql"
+```
+
+Apollo Engine identifies three categories of changes and report them to the developer on the command line or within a GitHub pull-request:
+
+* **Failure:** Either the schema is invalid or the changes will break current clients.
+* **Warning:** There are potential problems that may come from this change, but no clients are immediately impacted.
+* **Notice:** This change is safe and will not break current clients.
+
 <h2 id="monitoring">Monitor your graph's performance</h2>
+
+You need a bird's-eye view of your graph's API. Understanding how your schema fields, and queries operates within your graph service opens you to a whole new world of effective optimization and scaling!
+
+In order to get access to your graph's performance metrics, hook up Apollo Server with Engine.
+
+First, get an API key from [Engine](https://engine.apollographql.com). Now, connect to Engine by passing the API key to the Apollo Server constructor:
+
+_src/index.js_
+
+```js
+// Set up Apollo Server
+const server = new ApolloServer({
+  ...
+  ...
+  engine: process.env.ENGINE_API_KEY ? { apiKey: process.env.ENGINE_API_KEY } : undefined,
+});
+```
+
+Set the `ENGINE_API_KEY` environment variable via the command line:
+
+```bash
+$ ENGINE_API_KEY=YOUR_API_KEY npm start
+```
+
+Once this is done, you can now have access to all the features that Apollo Engine provides:
+
+* **Schema Explorer:** With Engine's powerful schema registry, you can quickly explore all the types and fields in your schema with usage statistics on each field. This metric makes you understand the cost of a field. How expensive is a field? Is a certain field in so much demand?
+* **Schema history:** Apollo Engine’s schema history allows developers to confidently iterate a graph's schema by validating the new schema against field-level usage data from the previous schema. This empowers developers to avoid breaking changes by providing insights into which clients will be broken by a new schema.
+* **Performance Analytics:** Fine-grained insights into every field, resolvers and operations of your graph's execution.
+* **Query tracing:**  The _Trace view_ in the Engine UI allows you to look at a detailed breakdown of the execution of one query, with timing for every resolver.
+* **Performance alerts:** You can configure notifications to be sent to various channels like Slack, and PagerDuty. Apollo Engine can be set to send alerts when a request rate, duration or error rate exceeds a certain threshold. You can effectively monitor everything going on in your graph's service.


### PR DESCRIPTION
This is the first draft for the `Run your graph in production` section.

The content here covers:

* Deploying your graph API to Now
* Publishing your schema to Engine via the Apollo CLI
* How to hook up Apollo Server with Engine for performance monitoring

The content here doesn't cover:
* Operation Registry
* VS code set up

