### PR TITLE
Updated resolvers.md, typo/inconsistent naming

### DIFF
--- a/docs/source/tutorial/resolvers.md
+++ b/docs/source/tutorial/resolvers.md
@@ -15,7 +15,7 @@ Before we can start writing resolvers, we need to learn more about what a resolv
 fieldName: (parent, args, context, info) => data
 ```
 
-* **root**: An object that contains the result returned from the resolver on the parent type
+* **parent**: An object that contains the result returned from the resolver on the parent type
 * **args**: An object that contains the arguments passed to the field
 * **context**: An object shared by all resolvers in a GraphQL operation. We use the context to contain per-request state such as authentication information and access our data sources.
 * **info**: Information about the execution state of the operation which should only be used in advanced cases


### PR DESCRIPTION
The function accepts the following arguments: parent, args, context, info
In the next paragraph, the 'parent' argument is explained but written as 'root' instead of 'parent'
You could also add somewhere in the sentence that the parent is root value passed from server.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->