### PR TITLE
Update to walkthrough: Deploy schema to Engine

### DIFF
--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -30,7 +30,7 @@ Our key is now stored under the environment variable `ENGINE_API_KEY`.
 It's time to publish our schema to Engine! First, start your server in one terminal window by running `npm start`. In another terminal window, run:
 
 ```bash
-npx apollo service:check && npx apollo service:push
+npx apollo schema:publish --endpoint=http://localhost:4000/graphql --key="service:your-api-key"
 ```
 
 > npx is a tool bundled with npm for easily running packages that are not installed globally.


### PR DESCRIPTION
When deploying a new schema the following fails: `apollo service:check`. It is able to load the apollo project, but fails at checking the service for changes. It returns this error: `Error: No service found to link to Engine`

I needed to use the snippet from Engine to deploy it:
```
npx apollo schema:publish --endpoint=http://localhost:4000/graphql --key="service:my-api-key"
```

Also, when I tried to use the original `npx apollo service:check && npx apollo service:push` command in a new terminal I had to set the engine api key envar in that window before running the command.