### PR TITLE
missing import of isEmail

### DIFF
--- a/docs/source/tutorial/resolvers.md
+++ b/docs/source/tutorial/resolvers.md
@@ -278,7 +278,9 @@ Let's open up `src/index.js` and update the `context` function on `ApolloServer`
 
 _src/index.js_
 
-```js line=4,8,10
+```js line=6,10,12
+const isEmail = require("isemail");
+
 const server = new ApolloServer({
   context: async ({ req }) => {
     // simple auth check on every request


### PR DESCRIPTION
current tutorial docs don't call out to import the required "isemail" module like the other example code sections do..

Hopefully this saves other people's time as I started to debug the actual User.js and resolver.js thinking it was something there I missed as I didn't understand how the "context" object worked yet.