### PR TITLE
Update client.md with Apollo Client 2.0 arguments

### DIFF
--- a/docs/source/tutorial/client.md
+++ b/docs/source/tutorial/client.md
@@ -58,9 +58,12 @@ _src/index.js_
 
 ```js
 import { ApolloClient } from "apollo-client";
+import { createHttpLink } from 'apollo-link-http';
+import { InMemoryCache } from 'apollo-cache-inmemory';
 
 const client = new ApolloClient({
-  uri: "http://localhost:4000/graphql"
+  link: createHttpLink({ uri: 'http://localhost:4000/graphql' }),
+  cache: new InMemoryCache()
 });
 ```
 


### PR DESCRIPTION
The client creation changed on Apollo Client 2.0, but the tutorial instructions are not up-to-date. This changes the client creation arguments according to https://www.apollographql.com/docs/react/recipes/2.0-migration.html