### PR TITLE
Pass in the correct variable name

### DIFF
--- a/docs/source/tutorial/data-source.md
+++ b/docs/source/tutorial/data-source.md
@@ -49,7 +49,7 @@ _src/datasources/launch.js_
 ```js
 async getAllLaunches() {
   const response = await this.get('launches');
-  return Array.isArray(result)
+  return Array.isArray(response)
     ? response.map(launch => this.launchReducer(launch))
     : [];
 }


### PR DESCRIPTION
We define the response variable but then pass in an undefined "result" variable