### PR TITLE
Fix Markdown formatting in client.md

### DIFF
--- a/docs/source/tutorial/client.md
+++ b/docs/source/tutorial/client.md
@@ -32,10 +32,12 @@ First, make a copy of the `.env.example` file located in `client/` and call it `
 ```
 ENGINE_API_KEY=service:<your-service-name>:<hash-from-apollo-engine>
 ```
- The entry should basically look something like this:
- ```
+
+The entry should basically look something like this:
+
+```
 ENGINE_API_KEY=service:my-service-439:E4VSTiXeFWaSSBgFWXOiSA
-```	```
+```
 
 Our key is now stored under the environment variable `ENGINE_API_KEY`. Apollo VSCode uses this API key to pull down your schema from the registry.
 


### PR DESCRIPTION
The formatting of [this article](https://www.apollographql.com/docs/tutorial/client.html) was broken:

![image](https://user-images.githubusercontent.com/101152/51609382-49d7c900-1f1a-11e9-9c7e-444f9a713db8.png)
