### PR TITLE
Use `yarn` instead of `npm install`

### DIFF
--- a/docs/source/tutorial/client.md
+++ b/docs/source/tutorial/client.md
@@ -14,7 +14,7 @@ While Apollo Client works with any view layer, it's most commonly used with Reac
 For this half of the tutorial, we will be working in the `client/` folder of the project. You should have the project already from the server portioned, but if you don't, make sure to clone [the tutorial](https://github.com/apollographql/fullstack-tutorial/). From the root of the project, run:
 
 ```bash
-cd start/client && npm install
+cd start/client && yarn
 ```
 
 Now, our dependencies are installed. Here are the packages we will be using to build out our frontend:


### PR DESCRIPTION
The demo project currently contains `yarn.lock`, not `package-lock.json`:

https://github.com/apollographql/fullstack-tutorial/tree/7948b85d747300fd4d1596b6173b9ee783431c75/start/client