### PR TITLE
Replace local state `initializers` with `cache.writeData`

### DIFF
--- a/docs/source/tutorial/local-state.md
+++ b/docs/source/tutorial/local-state.md
@@ -42,11 +42,11 @@ To build a client schema, we **extend** the types of our server schema and wrap 
 
 We can also add local fields to server data by extending types from our server. Here, we're adding the `isInCart` local field to the `Launch` type we receive back from our graph API.
 
-<h2 id="store-initializers">Initialize the store</h2>
+<h2 id="store-initialization">Initialize the store</h2>
 
-Now that we've created our client schema, let's learn how to initialize the store. Since queries execute as soon as the component mounts, it's important for us to warm the Apollo cache with some default state so those queries don't error out. We will need to create `initializers` for both `isLoggedIn` and `cartItems` to prevent these two local queries from erroring out:
+Now that we've created our client schema, let's learn how to initialize the store. Since queries execute as soon as the component mounts, it's important for us to warm the Apollo cache with some default state so those queries don't error out. We will need to write initial data to the cache for both `isLoggedIn` and `cartItems`:
 
-Jump back to `src/index.js` and notice we had already added the `initializers` on the `ApolloClient` constructor in the last section:
+Jump back to `src/index.js` and notice we had already added a `cache.writeData` call to prepare the cache, in the last section:
 
 _src/index.js_
 
@@ -59,14 +59,15 @@ const client = new ApolloClient({
       authorization: localStorage.getItem('token'),
     },
   }),
-  initializers: {
-    isLoggedIn: () => !!localStorage.getItem('token'),
-    cartItems: () => [],
+});
+
+cache.writeData({
+  data: {
+    isLoggedIn: !!localStorage.getItem('token'),
+    cartItems: [],
   },
 });
 ```
-
-These `initializers` will be called as soon as `ApolloClient` is created. They will also run if the store is reset.
 
 Now that we've added default state to the Apollo cache, let's learn how to query local data from within our React components.
 

--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -103,12 +103,15 @@ const client = new ApolloClient({
       authorization: localStorage.getItem('token'),
     },
   }),
-  initializers: {
-    isLoggedIn: () => !!localStorage.getItem('token'),
-    cartItems: () => [],
-  },
   resolvers,
   typeDefs,
+});
+
+cache.writeData({
+  data: {
+    isLoggedIn: !!localStorage.getItem('token'),
+    cartItems: [],
+  },
 });
 ```
 


### PR DESCRIPTION
Initializers are no longer part of the AC local state API. We're now recommending that people use `cache.writeData` directly, since it's already part of the Apollo Cache API and is more flexible.