### PR TITLE
Update `service:check` docs with new flags

### DIFF
--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -151,7 +151,7 @@ After analyzing the changes against current usage metrics, Apollo will identify 
 By default, the CLI will look at operations run within the last day in order to decide which changes are breaking. This period of time may not be large enough, so the `validationPeriod` flag accommodates custom timeframes:
 
 ```bash
-apollo service:check --validationPeriod="P2W"
+apollo service:check --validationPeriod=P2W
 ```
 
 > Valid durations are represented in ISO 8601. For reference, see: https://bit.ly/2DEJ3UN. It can also be provided as a number in seconds, i.e. 86400 for a single day.

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -162,6 +162,8 @@ Two other parameters for customizing the results of `service:check` are threshol
 - `queryCountThresholdPercentage` - Similar to `queryCountThreshold`, but expressed as a percentage of all operation volume.
   > Note: these flags are compatible with each other. In the case that both are provided, an operation must meet or exceed both thresholds.
 
+If you have requests for other filtering or threshold mechanisms, we'd love to hear them! Please feel free to submit a [feature request](https://github.com/apollographql/apollo-tooling/issues/new?template=feature-request.md) or PR to the [apollo-tooling](https://github.com/apollographql/apollo-tooling/) repo.
+
 ```bash
 apollo service:check \
 # Validate the schema against operations that have run in the last 5 days

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -19,7 +19,7 @@ It might be tempting to version a GraphQL API the same way, but it's unnecessary
 
 <h3 id="field-usage">Field usage</h3>
 
-Rather than returning extensive amounts of data which might not be necessary, GraphQL allows consumers to specify exactly what data they need. This field-based granularity is valuable and avoids "over-fetching" but also makes it more difficult to understand what data is currently being used.
+Rather than returning extensive amounts of data which might not be necessary, GraphQL allows consumers to specify exactly what data they need. This field-based granularity is valuable and avoids "over-fetching", but also makes it more difficult to understand which parts of the schema are being used.
 
 To improve the understanding of field usage within an API, Apollo Server extends GraphQL with rich tracing data that demonstrates _how_ a GraphQL field is used and _when_ it's safe to change or eliminate a field.
 

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -158,8 +158,9 @@ apollo service:check --validationPeriod="P2W"
 
 Two other parameters for customizing the results of `service:check` are threshold values. For example, you may wish to drop support for an old version of an app in order to remove some deprecated fields. Using these parameters, you can decide what amount of breakage is acceptable before shipping any breaking changes.
 
-- `queryCountThreshold` - This flag will only validate the schema against operations that have been executed the specified number of times within the provided duration.
-- `queryCountThresholdPercentage` - Similar to `queryCountThreshold`, but expressed as a percentage of all operations.
+- `queryCountThreshold` - This flag will only validate the schema against operations that have been executed at least the specified number of times within the provided duration.
+- `queryCountThresholdPercentage` - Similar to `queryCountThreshold`, but expressed as a percentage of all operation volume.
+  > Note: these flags are compatible with each other. In the case that both are provided, an operation must meet or exceed both thresholds.
 
 ```bash
 apollo service:check \

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -154,7 +154,7 @@ By default, the CLI will look at operations run within the last day in order to 
 apollo service:check --validationPeriod=P2W
 ```
 
-> Valid durations are represented in ISO 8601. For reference, see: https://bit.ly/2DEJ3UN. It can also be provided as a number in seconds, i.e. 86400 for a single day.
+> Valid durations are represented in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations). It can also be provided as a number in seconds, i.e. 86400 for a single day.
 
 Two other parameters for customizing the results of `service:check` are threshold values. For example, you may wish to drop support for an old version of an app in order to remove some deprecated fields. Using these parameters, you can decide what amount of breakage is acceptable before shipping any breaking changes.
 

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -9,18 +9,17 @@ A GraphQL schema can change in a number of ways between releases and, depending 
 
 By comparing a new schema to the last published schema, the Apollo Platform can highlight points of concern by showing detailed schema changes alongside current usage information for those fields. With this pairing of data, the risks of changes can be greatly reduced.
 
-
 <h2 id="versioning">Understanding schema changes</h2>
 
-Versioning is a technique to prevent necessary changes from becoming "breaking changes" which affect the existing consumers of an API.  These iterations might be as trivial as renaming a field, or as substantial as refactoring the whole data model.
+Versioning is a technique to prevent necessary changes from becoming "breaking changes" which affect the existing consumers of an API. These iterations might be as trivial as renaming a field, or as substantial as refactoring the whole data model.
 
-Developers who have worked with REST APIs in the past have probably recognized various patterns for versioning the API, commonly by using a different URI (e.g. `/api/v1`, `/api/v2`, etc.) or a query parameter (e.g. `?version=1`).  With this technique, an application can easily end up with many different API endpoints over time, and the question of _when_ an API can be deprecated can become problematic.
+Developers who have worked with REST APIs in the past have probably recognized various patterns for versioning the API, commonly by using a different URI (e.g. `/api/v1`, `/api/v2`, etc.) or a query parameter (e.g. `?version=1`). With this technique, an application can easily end up with many different API endpoints over time, and the question of _when_ an API can be deprecated can become problematic.
 
-It might be tempting to version a GraphQL API the same way, but it's unnecessary with the right techniques.  By following the strategies and precautions outlined in this guide and using Apollo tooling that adds clarity to every change, many iterations of an API can be served from a single endpoint.
+It might be tempting to version a GraphQL API the same way, but it's unnecessary with the right techniques. By following the strategies and precautions outlined in this guide and using Apollo tooling that adds clarity to every change, many iterations of an API can be served from a single endpoint.
 
 <h3 id="field-usage">Field usage</h3>
 
-Rather than returning extensive amounts of data which might not be necessary, GraphQL allows consumers to specify exactly what data they need.  This field-based granularity is valuable and avoids "over-fetching" but also makes it more difficult to understand what data is currently being used.
+Rather than returning extensive amounts of data which might not be necessary, GraphQL allows consumers to specify exactly what data they need. This field-based granularity is valuable and avoids "over-fetching" but also makes it more difficult to understand what data is currently being used.
 
 To improve the understanding of field usage within an API, Apollo Server extends GraphQL with rich tracing data that demonstrates _how_ a GraphQL field is used and _when_ it's safe to change or eliminate a field.
 
@@ -34,13 +33,13 @@ We'll go over these two kinds of field rollovers separately and show how to make
 
 <h3 id="renaming-or-removing">Renaming or removing a field</h3>
 
-When a field is unused, renaming or removing it is as straightforward as it sounds: it can be renamed or removed.  Unfortunately, if a GraphQL deployment doesn't have per-field usage metrics, additional considerations should be made.
+When a field is unused, renaming or removing it is as straightforward as it sounds: it can be renamed or removed. Unfortunately, if a GraphQL deployment doesn't have per-field usage metrics, additional considerations should be made.
 
 Take the following `user` query as an example:
 
 ```graphql
 type Query {
- user(id: ID!): User
+  user(id: ID!): User
 }
 ```
 
@@ -64,8 +63,8 @@ const getUserResolver = (root, args, context) => {
 const resolvers = {
   Query: {
     getUser: getUserResolver,
-    user: getUserResolver,
-  },
+    user: getUserResolver
+  }
 };
 ```
 
@@ -80,10 +79,10 @@ type Query {
 }
 ```
 
-GraphQL-aware client tooling, like GraphQL Playground and GraphiQL, use this information to assist developers in making the right choices.  These tools will:
+GraphQL-aware client tooling, like GraphQL Playground and GraphiQL, use this information to assist developers in making the right choices. These tools will:
 
-* Provide developers with the helpful deprecation message referring them to the new name.
-* Avoid auto-completing the field.
+- Provide developers with the helpful deprecation message referring them to the new name.
+- Avoid auto-completing the field.
 
 Over time, usage will fall for the deprecated field and grow for the new field.
 
@@ -125,7 +124,7 @@ If we wanted to leave the old `groupId` argument active, we wouldn't need to do 
 
 Instead of supporting it, if we wanted to remove the old argument, the safest option would be to create a new field and deprecate the current `getUsers` field.
 
-Using an API management tool, like the Apollo platform, it’s possible to determine when usage of an old field has dropped to an acceptable level and remove it.  The previously discussed [field rollover](#field-rollover) section gives more info on how to do that.
+Using an API management tool, like the Apollo platform, it’s possible to determine when usage of an old field has dropped to an acceptable level and remove it. The previously discussed [field rollover](#field-rollover) section gives more info on how to do that.
 
 Of course, it’s also possible to leave the field in place indefinitely!
 
@@ -171,7 +170,6 @@ apollo service:check \
 # Only validate against operations that account for at least 3% of total operation volume
 --queryCountThresholdPercentage=3
 ```
-
 
 <h2 id="github">GitHub Integration</h2>
 

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -148,7 +148,7 @@ After analyzing the changes against current usage metrics, Apollo will identify 
 
 <h3 id="cli-advanced">Advanced CLI Usage</h3>
 
-By default, the CLI will look at operations run within the last day in order to decide which changes are breaking. This period of time may not be large enough, so the `validationPeriod` flag accommodates custom timeframes:
+Depending on the requirements of your application, you may want to configure the timeframe to validate operations against. You can do so by providing a `validationPeriod` flag to the CLI. The timeframe will always end at "now", and go back in time by the amount specified.
 
 ```bash
 apollo service:check --validationPeriod=P2W

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -147,7 +147,31 @@ After analyzing the changes against current usage metrics, Apollo will identify 
 2. **Warning**: There are potential problems that may come from this change, but no clients are immediately impacted.
 3. **Notice**: This change is safe and will not break current clients.
 
-The more [performance metrics](./performance.html) that Apollo has, the better the report of these changes will become.
+<h3 id="cli-advanced">Advanced CLI Usage</h3>
+
+By default, the CLI will look at operations run within the last day in order to decide which changes are breaking. This period of time may not be large enough, so the `validationPeriod` flag accommodates custom timeframes:
+
+```bash
+apollo service:check --validationPeriod="P2W"
+```
+
+> Valid durations are represented in ISO 8601. For reference, see: https://bit.ly/2DEJ3UN. It can also be provided as a number in seconds, i.e. 86400 for a single day.
+
+Two other parameters for customizing the results of `service:check` are threshold values. For example, you may wish to drop support for an old version of an app in order to remove some deprecated fields. Using these parameters, you can decide what amount of breakage is acceptable before shipping any breaking changes.
+
+- `queryCountThreshold` - This flag will only validate the schema against operations that have been executed the specified number of times within the provided duration.
+- `queryCountThresholdPercentage` - Similar to `queryCountThreshold`, but expressed as a percentage of all operations.
+
+```bash
+apollo service:check \
+# Validate the schema against operations that have run in the last 5 days
+--validationPeriod=P5D \
+# Only validate against operations that have run at least 5 times during the 5 day duration
+--queryCountThreshold=5 \
+# Only validate against operations that account for at least 3% of total operation volume
+--queryCountThresholdPercentage=3
+```
+
 
 <h2 id="github">GitHub Integration</h2>
 

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -33,7 +33,7 @@ We'll go over these two kinds of field rollovers separately and show how to make
 
 <h3 id="renaming-or-removing">Renaming or removing a field</h3>
 
-When a field is unused, renaming or removing it is as straightforward as it sounds: it can be renamed or removed. Unfortunately, if a GraphQL deployment doesn't have per-field usage metrics, additional considerations should be made.
+When a field is unused, renaming or removing it is as straightforward as it sounds: it can be renamed or removed. However, if a GraphQL deployment doesn't have per-field usage metrics, additional considerations should be made. The following example demonstrates a safe approach to renaming a field.
 
 Take the following `user` query as an example:
 


### PR DESCRIPTION
This PR adds documentation for 3 new flags for the `service:check` CLI command:

* validationPeriod
* queryCountThreshold
* queryCountThresholdPercentage

Also removes a broken link to performance metrics `./performance.html`

This PR is best read by commits, since the second commit is strictly prettier re-formatting the markdown file.