### PR TITLE
Update: Non Breaking Changes documentation

### DIFF
--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -98,7 +98,7 @@ type Query {
   getUsers(ids: [ID!]!): [User]!
 
   # what we want to end up with
-  getUsers(ids: [ID!], groupId: ID!): [User]!
+  getUsers(ids: [ID!], groupId: ID): [User]!
 }
 ```
 


### PR DESCRIPTION
Having `groupId` as a required field would be a breaking change. As existing clients would now require this field when running this query.