### PR TITLE
Fix confusing highlight on data-source tutorial

### DIFF
--- a/docs/source/tutorial/data-source.md
+++ b/docs/source/tutorial/data-source.md
@@ -148,7 +148,7 @@ Adding our data sources is simple, just create a `dataSources` property on your 
 
 _src/index.js_
 
-```js line=3,4,10-13
+```js line=1,3,4,6,10-13
 const { createStore } = require('./utils');
 
 const LaunchAPI = require('./datasources/launch');


### PR DESCRIPTION
## Problems
The doc highlight can lead to user being confuse about what needed to be added in `src/index.js`

## Caveat
I do agree that Highlighting most of the box seems weird and remove the purpose of the highlight in the first place. But just highlighting a part of it is counter intuitive and can lead to the user being confuse.


### Before
<img width="803" alt="Screen Shot 2019-03-25 at 9 47 34 AM" src="https://user-images.githubusercontent.com/11723501/54924821-86587e80-4ee3-11e9-99ed-70587d0298d9.png">

### After
<img width="802" alt="Screen Shot 2019-03-25 at 9 55 34 AM" src="https://user-images.githubusercontent.com/11723501/54925214-3928dc80-4ee4-11e9-814c-0d6731501a91.png">
