### PR TITLE
remove `resolvers` & `typeDefs` fields

### DIFF
--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -103,8 +103,6 @@ const client = new ApolloClient({
       authorization: localStorage.getItem('token'),
     },
   }),
-  resolvers,
-  typeDefs,
 });
 
 cache.writeData({


### PR DESCRIPTION
These two fields should be introduced later in the course