### PR TITLE
Add compatible changes and update descriptions of breaking changes

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3848,7 +3848,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -5616,8 +5616,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5635,13 +5634,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5654,18 +5651,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5768,8 +5762,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5779,7 +5772,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5792,20 +5784,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5822,7 +5811,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5895,8 +5883,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5906,7 +5893,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5982,8 +5968,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6013,7 +5998,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6031,7 +6015,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6070,13 +6053,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9217,7 +9198,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         },
         "wordwrap": {
@@ -9529,7 +9510,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -11286,7 +11267,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -12522,7 +12503,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -241,3 +241,44 @@ apollo service:check \
 # Only validate against operations that account for at least 3% of total operation volume
 --queryCountThresholdPercentage=3
 ```
+
+<h2 id="compatible-changes">Compatible Changes</h2>
+
+The following changes are compatible with existing clients by default, since they will not affect the behavior of clients.
+
+#### Optional arguments
+
+Optional arguments include changes that add any input that can be nullable.
+Existing operations will not include the new value. The behavior of the clients will
+stay the same provided the result of the operation remains the same with a <code>null</code> input.
+
+  <ul>
+    <li id="OPTIONAL_ARG_ADDED"><code>OPTIONAL_ARG_ADDED</code> Nullable argument added to a field</li>
+    <li id="NULLABLE_FIELD_ADDED_TO_INPUT_OBJECT"><code>NULLABLE_FIELD_ADDED_TO_INPUT_OBJECT</code> Nullable field added to an input object</li>
+  </ul>
+
+#### Additions
+
+Additions are changes that will not affect client behavior, since clients
+will not access the new schema elements.
+
+  <ul>
+    <li id="FIELD_ADDED"><code>FIELD_ADDED</code> Field added to a type</li>
+    <li id="TYPE_ADDED"><code>TYPE_ADDED</code> Type added to the schema</li>
+    <li id="VALUE_ADDED_TO_ENUM"><code>VALUE_ADDED_TO_ENUM</code> Value added to an enum. If clients contain a switch case on the enum and do not include the `default`, this change could cause unexpected behavior</li>
+  </ul>
+
+#### Deprecations
+
+Deprecations will not affect the behavior of the clients directly, since
+they are a signal to developer to avoid the schema element rather than a
+behavior change.
+
+  <ul>
+    <li id="FIELD_DEPRECATED"><code>FIELD_DEPRECATED</code> Field deprecated</li>
+    <li id="FIELD_DEPRECATION_REMOVED"><code>FIELD_DEPRECATION_REMOVED</code> Field no longer deprecated</li>
+    <li id="FIELD_DEPRECATED_REASON_CHANGE"><code>FIELD_DEPRECATED_REASON_CHANGE</code> Reason for deprecation changed</li>
+    <li id="ENUM_DEPRECATED"><code>ENUM_DEPRECATED</code> Enum deprecated</li>
+    <li id="ENUM_DEPRECATION_REMOVED"><code>ENUM_DEPRECATION_REMOVED</code> Enum no longer deprecated</li>
+    <li id="ENUM_DEPRECATED_REASON_CHANGE"><code>ENUM_DEPRECATED_REASON_CHANGE</code> Reason for enum deprecation changed</li>
+  </ul>

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -3,7 +3,7 @@ title: Validating schema changes
 description: Check if proposed schema changes are safe or breaking by comparing against live server traffic
 ---
 
-As GraphQL scales within an organization, it becomes harder to evolve the schema while guaranteeing that no query or client will ever break from a change. Some organizations take the approach of just _never_ making schema changes that might be breaking; however, managing an only-ever-growing schema is unnecessarily difficult for most teams. It can actually be very safe to evolve the schema through field removals and return type changes if you have the right tools to guarantee that no such change will ever break an active query.
+As GraphQL scales within an organization, evolving the schema to contain necessary fields only while guaranteeing that no query or client will break from a change. Some organizations take the approach of _never_ making schema changes that might be breaking, which leads to an ever-growing schema and reduced api accessibility. In reality, removing field removal and updating return types is safe with tools to guarantee that no change will ever break an active query.
 
 As such, schema change validation is one of the cornerstones of the [Apollo Platform](/docs/intro/platform.html) and we've built a set of tools to make the workflow possible.
 
@@ -11,13 +11,13 @@ As such, schema change validation is one of the cornerstones of the [Apollo Plat
 
 <h2 id="schema-validation">How it works</h2>
 
-The schema validation mechanism utilizes both Apollo's schema registry and Apollo's trace warehouse. The **schema registry** is used to identify a "schema diff" with changes between schema versions. The **trace warehouse** is used to identify which clients and which operations are using which fields in the schema in real time. We compare each change in the schema diff against the live usage data to determine if that change will be a "breaking change" for any clients.
+The schema validation mechanism utilizes both Apollo's schema registry and Apollo's trace warehouse. The **schema registry** is used to compute a "schema diff" with changes between schema versions. The **trace warehouse** is used to identify which schema fields have been recently used by clients and operations seen in a deployed system. We compare each change in the schema diff against the live usage data to determine if that change is "breaking change" for any clients.
 
 Here's how it works:
 
 1. You run `apollo service:check` locally or in CI. The proposed schema is sent to Engine's schema registry.
 1. Engine creates a diff between the local schema and the most recently published schema in the registry.
-1. Engine fetches a list of all operations sent to your service in the last day (time window is [configurable](#cli-advanced)).
+1. Engine fetches a list of all operations sent to your service in your plan's maximum time window (time window is [configurable](#cli-advanced)).
 1. Engine walks through the schema diff change-by-change and compares against the operation list to see if the changes will affect the behavior of any operations.
 1. Engine will return the schema diff and indicate any breaking changes found.
 1. The CLI will print the output of this check with a link to _view more details in the Engine UI_.
@@ -28,7 +28,7 @@ Engine's cloud service uses an algorithm to detect breaking changes in a schema 
 
 #### Removals
 
-Each of these changes removes a schema element can be actively used by an operation. If removed, the GraphQL layer will return an error to the dependent operation.
+Each of these changes removes a schema element. If the element is actively used by an operation and removed, the GraphQL layer will return an error to the dependent operation.
 
 <ul>
   <li id="FIELD_REMOVED">
@@ -38,19 +38,19 @@ Each of these changes removes a schema element can be actively used by an operat
     <code>TYPE_REMOVED</code> Type(scalar, object) used by at least one operation was removed
   </li>
   <li id="ARG_REMOVED">
-    <code>ARG_REMOVED</code> Argument on a field used by at least one operation was removed
+    <code>ARG_REMOVED</code> Argument was removed from a field used by at least one operation
   </li>
   <li id="TYPE_REMOVED_FROM_UNION">
-    <code>TYPE_REMOVED_FROM_UNION</code> Type in a union used by at least one operation was removed
+    <code>TYPE_REMOVED_FROM_UNION</code> Type was removed from a union used by at least one operation
   </li>
   <li id="INPUT_FIELD_REMOVED">
-    <code>INPUT_FIELD_REMOVED</code> Field in an input type referenced by argument on field used by at least one operation was removed
+    <code>INPUT_FIELD_REMOVED</code> Field removed from an input type referenced by an argument on a field used by at least one operation
   </li>
   <li id="VALUE_REMOVED_FROM_ENUM">
-    <code>VALUE_REMOVED_FROM_ENUM</code> A value in an enum used by at least one operation was removed
+    <code>VALUE_REMOVED_FROM_ENUM</code> A value removed from an enum used by at least one operation
   </li>
   <li id="TYPE_REMOVED_FROM_INTERFACE">
-    <code>TYPE_REMOVED_FROM_INTERFACE</code> An object used by at least one operation was removed from an interface
+    <code>TYPE_REMOVED_FROM_INTERFACE</code> An object removed from an interface used by at least one operation
   </li>
 </ul>
 
@@ -71,18 +71,20 @@ Each of these changes adds a required input to a schema element. If an existing 
 
 Each of these changes updates an existing schema element. Any operation that uses the schema element could receive an error or in some cases an unexpected result.
 
+> Note: in some rare cases, these changes are compatible with the client at runtime, such as a type rename or an object to interface conversion with the same fields. Schema validation marks these breaking changes, since validation does not have enough information to ensure safety and the changes deserve extra scrutiny, such as their impact on type generation.
+
 <ul>
   <li id="FIELD_CHANGED_TYPE">
     <code>FIELD_CHANGED_TYPE</code> Field used by at least one operation changed return type
   </li>
   <li id="INPUT_FIELD_CHANGED_TYPE">
-    <code>INPUT_FIELD_CHANGED_TYPE</code> Field in input object referenced by argument on field used by at least one operation changed type
+    <code>INPUT_FIELD_CHANGED_TYPE</code> Field in input object changed type and is referenced by argument on field used by at least one operation
   </li>
   <li id="TYPE_CHANGED_KIND">
     <code>TYPE_CHANGED_KIND</code> Type used by at least one operation changed, ex: scalar to object or enum to union
   </li>
   <li id="ARG_CHANGED_TYPE">
-    <code>ARG_CHANGED_TYPE</code> Argument on field used by at least one operation changed a type
+    <code>ARG_CHANGED_TYPE</code> Argument changed type on field used by at least one operation
   </li>
 </ul>
 
@@ -109,22 +111,22 @@ These changes update the default value for an argument. If an operation does not
   </li>
 </ul>
 
-> **Note:** This is not an exhaustive list of all possible schema change types, just _breaking_ change types. Visit the [`graphql` package's repository](https://github.com/graphql/graphql-js/blob/9e404659a15d59c5ce12aae433dd2a636ea9eb82/src/utilities/findBreakingChanges.js#L39) for more details on schema changes types.
+> For the rest of the changes returned by `service:check`, see the [list of compatible changes](#compatible-changes)
 
-A failed `apollo schema:check` command will exit with a non-0 exit code and fail CI checks on purpose! There are actually many cases where it is safe to make a potentially breaking change, as long as the change is made intentionally.
+A failed `apollo service:check` command will exit with a non-0 exit code and fail CI checks! There are many cases where it is safe to make a potentially breaking change, as long as the change is made intentionally with an understanding of its impact.
 
-Since breaking changes are detected using live traffic, your service will need active metrics for the change algorithm to detect failures. If there are no metrics associated with your service, _all_ changes will be assigned the `NOTICE` severity as opposed to the `FAILURE` severity.
+Since breaking changes are detected using live traffic, **your service will need active metrics** for the change algorithm to detect failures. If there are no metrics associated with your service, _all_ changes will be assigned the `NOTICE` severity as opposed to the `FAILURE` severity.
 
 ### Validation output
 
 Running a schema validation check is as simple as running `apollo service:check` on the command line from within a service repository that has been configured to be an Apollo project.
 
-> **Note:** [Skip ahead](#setup) to the setup section for details on how to configure your project for schema change validation.
+> **Note:** [Skip to the setup section](#setup) for details on how to configure your project for schema change validation.
 
 Running the `apollo service:check` command will output the diff of all schema changes found and highlight changes determined to be breaking as `FAILURE`. Here's an example:
 
 ```console
-~example$ apollo schema:check
+~example$ apollo service:check
   ✔ Loading Apollo Project
   ✔ Checking service for changes
 
@@ -153,7 +155,7 @@ You will need to be actively sending traces to the Apollo trace warehouse and re
 1. [Set up trace reporting to Apollo Engine](/docs/platform/setup-analytics.html) (either through Apollo Server 2+ or the Engine proxy).
 1. [Set up schema registration in your continuous delivery pipeline](/docs/platform/schema-registry.html).
 
-For the `apollo schema:check` command to be configured properly, you will also need:
+For the `apollo service:check` command to be configured properly, you will also need:
 
 1. [A `.env` file with an `ENGINE_API_KEY`](/docs/platform/schema-registry.html#Get-your-Engine-API-key).
 1. [An `apollo.config.js` file with a `service` configured](/docs/platform/schema-registry.html#Create-an-apollo-config-js-file).
@@ -207,21 +209,26 @@ jobs:
 
 <h3 id="github">GitHub integration</h3>
 
+<div style="text-align:center">
+
 ![GitHub Status View](../img/schema-history/github-check.png)
 
-Like most tools, schema validation is best used when it is integrated directly into the rest of your workflow. If you're using GitHub, you can install the Apollo Engine GitHub app. This will enable Apollo's systems to send a webhook back to your project on each `apollo schema:check`, providing built-in pass/fail status checks on your pull requests.
+</div>
+
+Like most tools, schema validation is best used when it is integrated directly into the rest of your workflow. If you're using GitHub, you can install the Apollo Engine GitHub app. This will enable Apollo's systems to send a webhook back to your project on each `apollo service:check`, providing built-in pass/fail status checks on your pull requests.
 
 Go to [https://github.com/apps/apollo-engine](https://github.com/apps/apollo-engine) and click the `Configure` button to install the Apollo Engine integration on the appropriate GitHub profile or organization.
 
 <h3 id="multiple-environments">Multiple environments</h3>
 
-Product cycles move fast, and it’s common for a schemas to be slightly different across environments as changes make their way through your system. To accommodate for this, schemas can be registered under specific "schema tags
-, and checks can be performed against specific "schema tags".
+Product cycles move fast, and it’s common for schemas to be slightly different across environments as changes make their way through your system. To accommodate for this, schemas can be registered under specific schema tags and checks can be performed against specific schema tags.
 
-schema registry allows each schema to be registered under a “schema tag”. Tags are mostly commonly used to represent environments, but can also be used to represent things like branches and future schemas. Passing the `--tag` flag to `apollo service:check` specifies which schema to compare against, such as `prod` or `staging`. It's common to run checks against multiple different schema tags during continuous integration to ensure that all important deployments are accounted for. Checking multiple tags will result in check statuses similar to:
+Tags mostly commonly represent environments and can also indicate branches or future schemas. Passing the `--tag` flag to `apollo service:check` specifies which schema to compare against, such as `prod` or `staging`. It's common to run checks against multiple different schema tags during continuous integration to ensure that all important deployments are accounted for. Checking multiple tags will result in check statuses similar to:
 
 <div style="text-align:center">
+
 ![multiple service checks](../img/schema-validation/service-checks.png)
+
 </div>
 
 <h2 id="cli-advanced">Adjusting validation parameters</h2>

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -24,9 +24,11 @@ Here's how it works:
 
 <h3 id="algorithm">Breaking change detection</h3>
 
-Engine's cloud service uses an algorithm to detect breaking changes in a schema diff. It follows the following rules to determine which potentially breaking change types should actually _fail_ the `apollo service:check` command and return a non-0 exit code.
+Engine's cloud service uses an algorithm to detect breaking changes in a schema diff. It uses the following rules to determine which potentially breaking change types should actually _fail_ the `apollo service:check` command and return a non-0 exit code. If the changes are deployed without additional scrutiny, clients could experience unexpected behavior.
 
 #### Removals
+
+Each of these changes removes a schema element can be actively used by an operation. If removed, the GraphQL layer will return an error to the dependent operation.
 
 <ul>
   <li id="FIELD_REMOVED">
@@ -54,6 +56,8 @@ Engine's cloud service uses an algorithm to detect breaking changes in a schema 
 
 #### Required arguments
 
+Each of these changes adds a required input to a schema element. If an existing operation uses the schema element, the GraphQL layer will return an error to the dependent operation.
+
 <ul>
   <li id="REQUIRED_ARG_ADDED">
     <code>REQUIRED_ARG_ADDED</code> Non-nullable argument added to field used by at least one operation
@@ -64,6 +68,8 @@ Engine's cloud service uses an algorithm to detect breaking changes in a schema 
 </ul>
 
 #### In-place updates
+
+Each of these changes updates an existing schema element. Any operation that uses the schema element could receive an error or in some cases an unexpected result.
 
 <ul>
   <li id="FIELD_CHANGED_TYPE">
@@ -82,6 +88,8 @@ Engine's cloud service uses an algorithm to detect breaking changes in a schema 
 
 #### Type extensions
 
+These changes add a type to an existing union or interface. Any operation that uses the union or interface could receive an unexpected result depending on the fragment spreads requested.
+
 <ul>
   <li id="TYPE_ADDED_TO_UNION">
     <code>TYPE_ADDED_TO_UNION</code> New type added to a union used by at least one operation
@@ -91,7 +99,9 @@ Engine's cloud service uses an algorithm to detect breaking changes in a schema 
   </li>
 </ul>
 
-#### Optional arguments
+#### Default arguments
+
+These changes update the default value for an argument. If an operation does not specify a value for this argument and relies on the value, the operation can experience unexpected results, which can lead to modified client behavior.
 
 <ul>
   <li id="ARG_DEFAULT_VALUE_CHANGE">

--- a/docs/source/platform/schema-validation.md
+++ b/docs/source/platform/schema-validation.md
@@ -24,7 +24,7 @@ Here's how it works:
 
 <h3 id="algorithm">Breaking change detection</h3>
 
-Engine's cloud service uses an algorithm to detect breaking changes in a schema diff. It uses the following rules to determine which potentially breaking change types should actually _fail_ the `apollo service:check` command and return a non-0 exit code. If the changes are deployed without additional scrutiny, clients could experience unexpected behavior.
+Engine's cloud service uses an algorithm to detect breaking changes in a schema diff. The following sections describe the rules that determine when a change type _fails_ the `apollo service:check` command, which returns a non-0 exit code. If these changes are deployed without additional scrutiny, clients could experience unexpected behavior.
 
 #### Removals
 
@@ -32,19 +32,19 @@ Each of these changes removes a schema element can be actively used by an operat
 
 <ul>
   <li id="FIELD_REMOVED">
-    <code>FIELD_REMOVED</code> A field referenced by at least one operation was removed
+    <code>FIELD_REMOVED</code> Field used by at least one operation was removed
   </li>
   <li id="TYPE_REMOVED">
-    <code>TYPE_REMOVED</code> A referenced type(scalar, object) was removed
+    <code>TYPE_REMOVED</code> Type(scalar, object) used by at least one operation was removed
   </li>
   <li id="ARG_REMOVED">
-    <code>ARG_REMOVED</code> A referenced argument was removed
+    <code>ARG_REMOVED</code> Argument on a field used by at least one operation was removed
   </li>
   <li id="TYPE_REMOVED_FROM_UNION">
-    <code>TYPE_REMOVED_FROM_UNION</code> A type in a union used by at least one operation was removed
+    <code>TYPE_REMOVED_FROM_UNION</code> Type in a union used by at least one operation was removed
   </li>
   <li id="INPUT_FIELD_REMOVED">
-    <code>INPUT_FIELD_REMOVED</code> A field in an input type used by at least one operation was removed
+    <code>INPUT_FIELD_REMOVED</code> Field in an input type referenced by argument on field used by at least one operation was removed
   </li>
   <li id="VALUE_REMOVED_FROM_ENUM">
     <code>VALUE_REMOVED_FROM_ENUM</code> A value in an enum used by at least one operation was removed
@@ -76,13 +76,13 @@ Each of these changes updates an existing schema element. Any operation that use
     <code>FIELD_CHANGED_TYPE</code> Field used by at least one operation changed return type
   </li>
   <li id="INPUT_FIELD_CHANGED_TYPE">
-    <code>INPUT_FIELD_CHANGED_TYPE</code> Field in input object referenced in field argument used by at least one operation changed type
+    <code>INPUT_FIELD_CHANGED_TYPE</code> Field in input object referenced by argument on field used by at least one operation changed type
   </li>
   <li id="TYPE_CHANGED_KIND">
     <code>TYPE_CHANGED_KIND</code> Type used by at least one operation changed, ex: scalar to object or enum to union
   </li>
   <li id="ARG_CHANGED_TYPE">
-    <code>ARG_CHANGED_TYPE</code> Argument used by at least one operation changed a type
+    <code>ARG_CHANGED_TYPE</code> Argument on field used by at least one operation changed a type
   </li>
 </ul>
 
@@ -92,10 +92,10 @@ These changes add a type to an existing union or interface. Any operation that u
 
 <ul>
   <li id="TYPE_ADDED_TO_UNION">
-    <code>TYPE_ADDED_TO_UNION</code> New type added to a union used by at least one operation
+    <code>TYPE_ADDED_TO_UNION</code> Type added to a union used by at least one operation
   </li>
   <li id="TYPE_ADDED_TO_INTERFACE">
-    <code>TYPE_ADDED_TO_INTERFACE</code> New interface added to an object used by at least one operation
+    <code>TYPE_ADDED_TO_INTERFACE</code> Interface added to an object used by at least one operation
   </li>
 </ul>
 
@@ -105,7 +105,7 @@ These changes update the default value for an argument. If an operation does not
 
 <ul>
   <li id="ARG_DEFAULT_VALUE_CHANGE">
-    <code>ARG_DEFAULT_VALUE_CHANGE</code> Default value added or changed for argument on a field that is used by at least one operation
+    <code>ARG_DEFAULT_VALUE_CHANGE</code> Default value added or changed for argument on a field used by at least one operation
   </li>
 </ul>
 


### PR DESCRIPTION
To enable all of the links in the engine frontend, we include all of the changes in the list.

This PR also provides more context around why a change fails the `service:check` command.