### PR TITLE
Remove --prefix-paths in development

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "start": "gatsby develop --prefix-paths"
+    "start": "gatsby develop"
   },
   "dependencies": {
     "gatsby": "2.3.14",


### PR DESCRIPTION
This branch removes the `--prefix-paths` option from `gatsby develop` in our NPM start script for the docs.