### PR TITLE
Registry plugin `dryRun` documentation

### DIFF
--- a/docs/source/platform/operation-registry.md
+++ b/docs/source/platform/operation-registry.md
@@ -5,15 +5,15 @@ description: How to secure your graph with operation safelisting
 
 ## Overview
 
-> The operation registry is an Apollo Platform feature available on the [_Team_ and _Enterprise_ plans](https://www.apollographql.com/plans/).  To get started with the Apollo Platform, begin with [the documentation](https://www.apollographql.com/docs/).
+> The operation registry is an Apollo Platform feature available on the [_Team_ and _Enterprise_ plans](https://www.apollographql.com/plans/). To get started with the Apollo Platform, begin with [the documentation](https://www.apollographql.com/docs/).
 
 Any API requires security and confidence prior to going to production. During development, GraphQL offers front-end engineers the ability to explore all the data available to them and fetch exactly what they need for the components they're building. However, in production, it can be unnecessary and undesirable to provide this flexibility.
 
 The Apollo Operation Registry allows organizations to:
 
-* Provide demand control for their production GraphQL APIs.
-* Permit the exact operations necessary for their client applications.
-* Eliminate the risk of unexpected, and possibly costly, operations being executed against their graph.
+- Provide demand control for their production GraphQL APIs.
+- Permit the exact operations necessary for their client applications.
+- Eliminate the risk of unexpected, and possibly costly, operations being executed against their graph.
 
 Operations defined within client applications are automatically extracted and uploaded to Apollo Engine using the Apollo CLI. Apollo Server fetches a manifest of these operations from Apollo Engine and forbids execution of operations which were not registered from the client bundle.
 
@@ -21,12 +21,12 @@ Operations defined within client applications are automatically extracted and up
 
 ### Prerequisites
 
-* Apollo Server 2.2.x (or newer).
-  * Subscriptions should be disabled when using the operation registry.  For more information, see the instructions below.  Please contact the Apollo sales team if this support is necessary.
-  * To get started with Apollo Server, visit [its documentation](/docs/apollo-server/).
-* A client application which utilizes `gql` tagged template literals for its operations or, alternatively, stores operations in `.graphql` files.
-* An Apollo Engine API key.
-  * To obtain an API key, visit [Apollo Engine](https://engine.apollographql.com) and create a service.
+- Apollo Server 2.2.x (or newer).
+  - Subscriptions should be disabled when using the operation registry. For more information, see the instructions below. Please contact the Apollo sales team if this support is necessary.
+  - To get started with Apollo Server, visit [its documentation](/docs/apollo-server/).
+- A client application which utilizes `gql` tagged template literals for its operations or, alternatively, stores operations in `.graphql` files.
+- An Apollo Engine API key.
+  - To obtain an API key, visit [Apollo Engine](https://engine.apollographql.com) and create a service.
 
 ### Installation steps
 
@@ -34,8 +34,8 @@ Operations defined within client applications are automatically extracted and up
 
 These installation steps require access to both the client and server codebases to perform the following tasks:
 
-* The `apollo` CLI is used to search the client codebase for GraphQL operations and upload them to Apollo Engine.
-* Apollo Server is then configured with a plugin which fetches the manifest from Apollo Server and enforces safe-listing using that manifest.
+- The `apollo` CLI is used to search the client codebase for GraphQL operations and upload them to Apollo Engine.
+- Apollo Server is then configured with a plugin which fetches the manifest from Apollo Server and enforces safe-listing using that manifest.
 
 The following steps will walk through the steps necessary for both the client and server codebases.
 
@@ -81,10 +81,10 @@ Now we'll use `apollo client:push` to locate operations within the client codeba
 
 The `apollo client:push` command:
 
-* Supports multiple client bundles. Each bundle is identified by a `clientName` (e.g. `react-web`).
-* Supports JavaScript, TypeScript and `.graphql` files.
-* Accepts a list of files as a glob (e.g. `src/**/*.ts`) to search for GraphQL operations.
-* By default, includes the `__typename` fields which are added by Apollo Client at runtime.
+- Supports multiple client bundles. Each bundle is identified by a `clientName` (e.g. `react-web`).
+- Supports JavaScript, TypeScript and `.graphql` files.
+- Accepts a list of files as a glob (e.g. `src/**/*.ts`) to search for GraphQL operations.
+- By default, includes the `__typename` fields which are added by Apollo Client at runtime.
 
 To register operations, use the following command as a reference, taking care to replace the `<ENGINE_API_KEY>` with the appropriate Apollo Engine API key, specifying a unique name for this application with `<CLIENT_IDENTIFIER>`, and indicating the correct glob of files to search:
 
@@ -106,7 +106,7 @@ If you encounter any errors, check the _**Troubleshooting**_ section below.
 
 **4. Disable subscription support on Apollo Server**
 
-Subscription support is enabled by default in Apollo Server 2.x and provided by a separate server which does not utilize Apollo Server 2.x's primary request pipeline.  Therefore, the operation registry plugin (and any plugin) is unable to be invoked during a request which comes into the subscription server and enforcement of operation safelisting is not possible. **For proper enforcement of operation safelisting, subscriptions should be disabled.**
+Subscription support is enabled by default in Apollo Server 2.x and provided by a separate server which does not utilize Apollo Server 2.x's primary request pipeline. Therefore, the operation registry plugin (and any plugin) is unable to be invoked during a request which comes into the subscription server and enforcement of operation safelisting is not possible. **For proper enforcement of operation safelisting, subscriptions should be disabled.**
 
 In the future, the subscription support will have its request pipeline unified with that of the main request pipeline, thus enabling plugin support and permitting the the operation registry to work with subscriptions in the same way that it works with regular GraphQL requests.
 
@@ -118,7 +118,7 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   // Ensure that subscriptions are disabled.
-  subscriptions: false,
+  subscriptions: false
   // ...
 });
 ```
@@ -147,9 +147,9 @@ const server = new ApolloServer({
   // New configuration
   plugins: [
     require('apollo-server-plugin-operation-registry')({
-      forbidUnregisteredOperations: true,
-    }),
-  ],
+      forbidUnregisteredOperations: true
+    })
+  ]
 });
 ```
 
@@ -168,7 +168,7 @@ Alternatively, the API key can be specified with the `engine` parameter on the A
 ```js line=3
 const server = new ApolloServer({
   // ...
-  engine: '<ENGINE_API_KEY>',
+  engine: '<ENGINE_API_KEY>'
   // ...
 });
 ```
@@ -205,7 +205,7 @@ In some cases, deployments may want to selectively enable the behavior of `forbi
 
 To selectively enable operation safe-listing, the `forbidUnregisteredOperations` setting supports a [predicate function](https://en.wikipedia.org/wiki/Predicate_(mathematical_logic) which receives the request context and can return `true` or `false` to indicate whether enforcement is enabled or disabled respectively.
 
-> In the example below, the `context` is the shared request context which can be modified per-request by plugins or using the [`context`](https://www.apollographql.com/docs/apollo-server/api/apollo-server.html#constructor-options-lt-ApolloServer-gt) function on the `ApolloServer` constructor.  The `headers` are the HTTP headers of the request which are accessed in the same way as the [Fetch API `Headers` interface](https://developer.mozilla.org/en-US/docs/Web/API/Headers) (e.g. `get(...)`, `has(...)`, etc.).
+> In the example below, the `context` is the shared request context which can be modified per-request by plugins or using the [`context`](https://www.apollographql.com/docs/apollo-server/api/apollo-server.html#constructor-options-lt-ApolloServer-gt) function on the `ApolloServer` constructor. The `headers` are the HTTP headers of the request which are accessed in the same way as the [Fetch API `Headers` interface](https://developer.mozilla.org/en-US/docs/Web/API/Headers) (e.g. `get(...)`, `has(...)`, etc.).
 
 For example, to enforce the operation registry safe-listing while skipping enforcement for any request in which the `Let-me-pass` header was present with a value of `Pretty please?`, the following configuration could be used:
 
@@ -215,9 +215,9 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   subscriptions: false,
-  engine: "<ENGINE_API_KEY>",
+  engine: '<ENGINE_API_KEY>',
   plugins: [
-    require("apollo-server-plugin-operation-registry")({
+    require('apollo-server-plugin-operation-registry')({
       // De-structure the object to get the HTTP `headers` and the GraphQL
       // request `context`.  Additional validation is possible, but this
       // function must be synchronous.  For more details, see the note below.
@@ -228,7 +228,7 @@ const server = new ApolloServer({
         }
       }) {
         // If a magic header is in place, allow any unregistered operation.
-        if (headers.get("Let-me-pass") === "Pretty please?") {
+        if (headers.get('Let-me-pass') === 'Pretty please?') {
           return false;
         }
 
@@ -240,9 +240,9 @@ const server = new ApolloServer({
 });
 ```
 
-> *Note:* The `forbidUnregisteredOperations` callback must be synchronous.  If it is necessary to make an `async` request (e.g. a database inquiry) to make a determination about access, such a lookup should occur within the [`context` function](https://www.apollographql.com/docs/apollo-server/api/apollo-server.html#constructor-options-lt-ApolloServer-gt) on the `ApolloServer` constructor (or any life-cycle event which has access to `context`) and the result will be available on the `context` of `forbidUnregisteredOperations`.
+> _Note:_ The `forbidUnregisteredOperations` callback must be synchronous. If it is necessary to make an `async` request (e.g. a database inquiry) to make a determination about access, such a lookup should occur within the [`context` function](https://www.apollographql.com/docs/apollo-server/api/apollo-server.html#constructor-options-lt-ApolloServer-gt) on the `ApolloServer` constructor (or any life-cycle event which has access to `context`) and the result will be available on the `context` of `forbidUnregisteredOperations`.
 
-## Testing the plugin ##
+## Testing the plugin
 
 We recommend testing the behavior of the plugin as well as your `forbidUnregisteredOperations` function before actually forbidding operation execution in production. To do so, you can use the `dryRun` option, which will log information about the operation in leiu of actually forbidding anything.
 
@@ -275,7 +275,7 @@ Could not fetch manifest
 </Error>
 ```
 
-This can occur if the schema hasn't been published since the operation registry plugin was enabled.  You can publish the schema using the `apollo service:push` command.  When receiving this message on a service which has already had its schema pushed, the `apollo client:push` command can be used.  Check the above documentation for more information on how to use those commands.
+This can occur if the schema hasn't been published since the operation registry plugin was enabled. You can publish the schema using the `apollo service:push` command. When receiving this message on a service which has already had its schema pushed, the `apollo client:push` command can be used. Check the above documentation for more information on how to use those commands.
 
 #### Operations aren't being forbidden or operations which should be permitted are not allowed
 

--- a/docs/source/platform/operation-registry.md
+++ b/docs/source/platform/operation-registry.md
@@ -244,7 +244,7 @@ const server = new ApolloServer({
 
 ## Testing the plugin
 
-We recommend testing the behavior of the plugin as well as your `forbidUnregisteredOperations` function before actually forbidding operation execution in production. To do so, you can use the `dryRun` option, which will log information about the operation in leiu of actually forbidding anything.
+We recommend testing the behavior of the plugin, as well as your `forbidUnregisteredOperations` function, before actually forbidding operation execution in production. To do so, you can use the `dryRun` option, which will log information about the operation in lieu of actually forbidding anything.
 
 ```js line=7
 const server = new ApolloServer({

--- a/docs/source/platform/operation-registry.md
+++ b/docs/source/platform/operation-registry.md
@@ -242,6 +242,23 @@ const server = new ApolloServer({
 
 > *Note:* The `forbidUnregisteredOperations` callback must be synchronous.  If it is necessary to make an `async` request (e.g. a database inquiry) to make a determination about access, such a lookup should occur within the [`context` function](https://www.apollographql.com/docs/apollo-server/api/apollo-server.html#constructor-options-lt-ApolloServer-gt) on the `ApolloServer` constructor (or any life-cycle event which has access to `context`) and the result will be available on the `context` of `forbidUnregisteredOperations`.
 
+## Testing the plugin ##
+
+We recommend testing the behavior of the plugin as well as your `forbidUnregisteredOperations` function before actually forbidding operation execution in production. To do so, you can use the `dryRun` option, which will log information about the operation in leiu of actually forbidding anything.
+
+```js line=7
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  plugins: [
+    require("apollo-server-plugin-operation-registry")({
+      forbidUnregisteredOperations: true,
+      dryRun: true
+    });
+  ],
+});
+```
+
 ## Troubleshooting
 
 #### The server indicates `Access denied.` (or `AccessDenied`) when fetching the manifest


### PR DESCRIPTION
This PR adds documentation that explains the new `dryRun` option for the operation registry plugin.

For reference: https://github.com/apollographql/apollo-platform-commercial/pull/71