### PR TITLE
Move the _redirects file to the public dir

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base    = "docs/"
   publish = "docs/public/"
-  command = "gatsby build --prefix-paths && mkdir -p docs && mv public/* docs && mv docs public/"
+  command = "gatsby build --prefix-paths && mkdir -p docs && mv public/* docs && mv docs public/ && mv public/docs/_redirects public"
 [build.environment]
   NPM_VERSION = "6"


### PR DESCRIPTION
This branch fixes Netlify redirects for this repo by adding an additional deploy command that moves the `_redirects` file to the public directory where it belongs. This should fix clicking on deploy preview links and cause all redirects to work again.