### PR TITLE
Fix link for "Setup Analytics" which was moved.

### DIFF
--- a/docs/source/references/engine-proxy.md
+++ b/docs/source/references/engine-proxy.md
@@ -3,7 +3,7 @@ title: Apollo Engine proxy (deprecated)
 description: Configuring and running the Engine proxy
 ---
 
-> DEPRECATED: The engine proxy is not maintained, and to integrate with the Apollo platform's metrics, we recommend using Apollo Server's native reporting functionality. To integrate a non-Node server, take a look at our guide [here](https://www.apollographql.com/docs/platform/setup-analytics#other-servers)
+> DEPRECATED: The engine proxy is not maintained, and to integrate with the Apollo platform's metrics, we recommend using Apollo Server's native reporting functionality. To integrate a non-Node server, take a look at our guide [here](https://www.apollographql.com/docs/references/setup-analytics#other-servers).
 
 ## Background
 

--- a/docs/source/references/engine-proxy.md
+++ b/docs/source/references/engine-proxy.md
@@ -3,7 +3,7 @@ title: Apollo Engine proxy (deprecated)
 description: Configuring and running the Engine proxy
 ---
 
-> DEPRECATED: The engine proxy is not maintained, and to integrate with the Apollo platform's metrics, we recommend using Apollo Server's native reporting functionality. To integrate a non-Node server, take a look at our guide [here](https://www.apollographql.com/docs/references/setup-analytics#other-servers).
+> DEPRECATED: The engine proxy is not maintained, and to integrate with the Apollo platform's metrics, we recommend using Apollo Server's native reporting functionality. To integrate a non-Node server, take a look at our guide [here](./setup-analytics#other-servers).
 
 ## Background
 


### PR DESCRIPTION
This page was moved shortly after it was created so a redirect doesn't seem necessary, but updating the also recently-added links to the new location seems important!