### PR TITLE
Rename operation-registry to operation-safelisting

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -27,7 +27,7 @@ module.exports = {
             'platform/schema-registry',
             'platform/schema-validation',
             'platform/client-awareness',
-            'platform/operation-registry',
+            'platform/operation-safelisting',
             'platform/editor-plugins',
             'platform/performance',
             'platform/integrations'

--- a/docs/source/platform/operation-safelisting.md
+++ b/docs/source/platform/operation-safelisting.md
@@ -1,6 +1,6 @@
 ---
-title: Operation registry
-description: How to secure your graph with operation safelisting
+title: Operation safelisting
+description: How to secure your graph by enforcing a safelist of registered operations
 ---
 
 ## Overview

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,7 +1,7 @@
 / /docs/
 
 # Redirect Removed Guides to Platform Features
-/docs/guides/security.html /docs/platform/operation-registry.html
+/docs/guides/security.html /docs/platform/operation-safelisting.html
 /docs/guides/monitoring.html /docs/platform/integrations.html
 /docs/guides/versioning.html /docs/platform/schema-validation.html#versioning
 
@@ -17,6 +17,7 @@
 
 /docs/platform/tracing.html /docs/platform/performance.html
 /docs/platform/errors.html /docs/platform/performance.html
+/docs/platform/operation-registry.html /docs/platform/operation-safelisting.html
 
 # File uploads no longer have a home, but the blog post is the same content.
 /docs/guides/file-uploads.html https://blog.apollographql.com/file-uploads-with-apollo-server-2-0-5db2f3f60675


### PR DESCRIPTION
This is a spin-off of thoughts from #354.

We've been slowly transiting the Platform docs articles to describe workflows as opposed to features/fixtures; i.e. the "why" instead of the "what". Renaming this article to "Operation Safelisting" as opposed "Operation Registry" is in line with that plan, as the safelisting is the reason why one would opt into using the operation registry today.

Platform docs articles:
![image](https://user-images.githubusercontent.com/5922187/58443316-195d9280-80a6-11e9-81e0-727baa15e090.png)

We may want to consider having multiple articles to represent the operation registry in the future, just like we have two to represent the schema registry ([Tracking your GraphQL schema](https://www.apollographql.com/docs/platform/schema-registry) and [Validating schema changes](https://www.apollographql.com/docs/platform/schema-validation)). We should do that when the time comes.



