### PR TITLE
Revert "Rename operation-registry to operation-safelisting"

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -27,7 +27,7 @@ module.exports = {
             'platform/schema-registry',
             'platform/schema-validation',
             'platform/client-awareness',
-            'platform/operation-safelisting',
+            'platform/operation-registry',
             'platform/editor-plugins',
             'platform/performance',
             'platform/integrations'

--- a/docs/source/platform/operation-registry.md
+++ b/docs/source/platform/operation-registry.md
@@ -1,6 +1,6 @@
 ---
-title: Operation safelisting
-description: How to secure your graph by enforcing a safelist of registered operations
+title: Operation registry
+description: How to secure your graph with operation safelisting
 ---
 
 ## Overview

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,7 +1,7 @@
 / /docs/
 
 # Redirect Removed Guides to Platform Features
-/docs/guides/security.html /docs/platform/operation-safelisting.html
+/docs/guides/security.html /docs/platform/operation-registry.html
 /docs/guides/monitoring.html /docs/platform/integrations.html
 /docs/guides/versioning.html /docs/platform/schema-validation.html#versioning
 
@@ -17,7 +17,6 @@
 
 /docs/platform/tracing.html /docs/platform/performance.html
 /docs/platform/errors.html /docs/platform/performance.html
-/docs/platform/operation-registry.html /docs/platform/operation-safelisting.html
 
 # File uploads no longer have a home, but the blog post is the same content.
 /docs/guides/file-uploads.html https://blog.apollographql.com/file-uploads-with-apollo-server-2-0-5db2f3f60675


### PR DESCRIPTION
Reverts apollographql/apollo#455

As has always been our policy for moving documentation around, this should have a redirect setup for it to preserve existing links.  I'm reverting it because that should be done as part of the rename and currently, existing links would be broken because of this.  

Additionally, I do think we should discuss it first.