### PR TITLE
Document how to configure schemaTag in operation registry plugin - AP-468

### DIFF
--- a/docs/source/platform/operation-registry.md
+++ b/docs/source/platform/operation-registry.md
@@ -118,6 +118,10 @@ Currently, once an operation is registered it will remain registered indefinitel
 
 If you encounter any errors, check the _**Troubleshooting**_ section below.
 
+####3.1 Optionally, set the schema tag  
+
+To specify the schema tag to register operations on, pass an additional `--tag <TAG>` argument (`npx apollo client:push --tag <TAG>`).
+
 ### 4. Disable subscription support on Apollo Server
 
 Subscription support is enabled by default in Apollo Server 2.x and provided by a separate server which does not utilize Apollo Server 2.x's primary request pipeline. Therefore, the operation registry plugin (and any plugin) is unable to be invoked during a request which comes into the subscription server and enforcement of operation safelisting is not possible. **For proper enforcement of operation safelisting, subscriptions should be disabled.**

--- a/docs/source/platform/operation-registry.md
+++ b/docs/source/platform/operation-registry.md
@@ -28,9 +28,6 @@ Operations defined within client applications can be extracted and uploaded to A
 ### Limitations
 
 - Subscriptions within Apollo Server should be disabled. For more information, see the instructions below.
-- Only the default schema tag (`current`) is supported.
-
-  To use the operation registry with schema tags, the schema which necessitates demand control should also be registered to the default (`current`) tag for the same service. For example, if a service is using a `prod` schema tag and publishing the schema with `apollo service:push --tag=prod`, the same schema should also be pushed to the default tag with `apollo service:push --tag=current`.
 
 Please [contact the Apollo sales team](https://www.apollographql.com/contact-sales/) if you require a solution to any of these limitations.
 
@@ -163,6 +160,23 @@ const server = new ApolloServer({
   plugins: [
     require("apollo-server-plugin-operation-registry")({
       forbidUnregisteredOperations: true
+    })
+  ]
+});
+```
+
+####5.1 Optionally, set the schema tag
+
+The plugin will automatically pickup the value of the environment variable `ENGINE_SCHEMA_TAG` and use that as the schema tag.  
+
+To override this behaviour, configure the `schemaTag` field.  
+
+```js
+const server = new ApolloServer({
+  // Existing configuration
+  plugins: [
+    require("apollo-server-plugin-operation-registry")({
+      schemaTag: 'overrideTag' // highlight-line
     })
   ]
 });

--- a/docs/source/platform/operation-registry.md
+++ b/docs/source/platform/operation-registry.md
@@ -171,9 +171,7 @@ const server = new ApolloServer({
 
 ####5.1 Optionally, set the schema tag
 
-The plugin will automatically pickup the value of the environment variable `ENGINE_SCHEMA_TAG` and use that as the schema tag.  
-
-To override this behaviour, configure the `schemaTag` field.  
+Configure the `schemaTag` field to specify which tag to pull operation manifests from.  
 
 ```js
 const server = new ApolloServer({


### PR DESCRIPTION
(Note: can merge after https://github.com/apollographql/apollo-tooling/pull/1307 is released. update: released)

This PR adds 2 optional sub-steps in the setup flow to demonstrate how to configure the schema tag for the operation registry plugin and the cli  

It also removes the "Only the default schema tag (`current`) is supported." section from the "Limitations" section