### PR TITLE
Change missionPatch type to String

### DIFF
--- a/docs/source/tutorial/resolvers.md
+++ b/docs/source/tutorial/resolvers.md
@@ -257,7 +257,7 @@ _src/schema.js_
 ```js
   type Mutation {
     # ... with rest of schema
-    missionPatch(mission: String, size: PatchSize): PatchSize
+    missionPatch(mission: String, size: PatchSize): String
   }
 ```
 


### PR DESCRIPTION
`missionPatch`'s type in the schema must have accidentally been changed from `String` to `PatchSize` when a resolver was added.

This causes a fairly difficult to debug error in the Client UI while working through the tutorial. (at least for graphQL newbies like me 😛 )