### PR TITLE
Indicate how options affect metrics reporting

### DIFF
--- a/docs/source/platform/operation-registry.md
+++ b/docs/source/platform/operation-registry.md
@@ -289,6 +289,7 @@ const server = new ApolloServer({
   ],
 });
 ```
+> Note: by setting `forbidUnregisteredOperations: true`, metrics will be reported to the Apollo Trace Warehouse indicating that operations are forbidden, even though they've been permitted. Behavior of the plugin will remain the same if the `forbidUnregisteredOperations` option is left unset, though operations will not be reported as forbidden.
 
 ## Troubleshooting
 


### PR DESCRIPTION
It is a feature of the operation safelisting plugin that operations will be reported as forbidden if the user explicitly sets `forbidUnregisteredOperations`. See https://github.com/apollographql/apollo-platform-commercial/pull/155.