### PR TITLE
[WIP] Federation: Stub PR to update `service:push`

### DIFF
--- a/docs/source/platform/schema-registry.mdx
+++ b/docs/source/platform/schema-registry.mdx
@@ -13,6 +13,8 @@ Apollo includes a schema registry that serves as a [central hub](https://princip
 - Tools like the [Apollo VS Code extension](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) can automatically fetch your schema from the registry and provide intellisense like field descriptions and deprecations directly in your editor.
 - Apollo's registry lets you track related _variants_ of a schema, like staging or alpha versions. It's helpful to have these schema definitions handy without having to juggle running servers that implement them.
 
+> Using Federation? [Skip ahead](<FIXME>) to learn how to register partial schemas with the schema registry
+
 ## Using the Schema Registry
 
 To get started using the schema registry, you'll need to make sure your repository is configured to be an Apollo project.
@@ -43,6 +45,12 @@ id      schema        tag
 ──────  ────────────  ───────
 190330  example-4218  current
 ```
+
+## Registering a schema with Federation
+
+If you're running a distributed GraphQL infrastructure, where GraphQL microservices [compose](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#fetch-service-capabilities) to form a complete schema, there's functionality to register each service's partial schema and still get all of the benefits of the schema registry.
+
+... // TODO
 
 ### Hooking into CI
 

--- a/docs/source/platform/schema-registry.mdx
+++ b/docs/source/platform/schema-registry.mdx
@@ -3,6 +3,10 @@ title: Tracking your GraphQL schema
 description: A central hub for your GraphQL API
 ---
 
+[//]: # (Description: This doc should be updated to make it clear that if you're running your graph using federation, you should be registering your **services** and if you're running your graph as a monolith, you should register your overall schema. There is an opportunity here to consider that everyone could register even monoliths as graphs with a single implementing service, though my gut feeling is that might be more confusing as a start to most people who won't need to think about federation. Basically, the people who come to this doc without federation should be easily able to ignore the federation-specific stuff, and the people who come to this doc for federation needs should be able to find the "new" information easily. We should make sure to use the same pattern, whether it be a toggle or italics or whatever, from the schema validation docs in #503.)
+[//]: # (Assignee: Jake)
+[//]: # (Reviewer: Chang, Caydie)
+
 import ProjectConfigPanel from 'gatsby-theme-apollo-docs/mdx/project-config-panel.mdx';
 
 Apollo includes a schema registry that serves as a [central hub](https://principledgraphql.com/integrity#3-track-the-schema-in-a-registry) for tracking your GraphQL schema. Adopting a shared schema registry for your project has many benefits:
@@ -13,9 +17,11 @@ Apollo includes a schema registry that serves as a [central hub](https://princip
 - Tools like the [Apollo VS Code extension](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) can automatically fetch your schema from the registry and provide intellisense like field descriptions and deprecations directly in your editor.
 - Apollo's registry lets you track related _variants_ of a schema, like staging or alpha versions. It's helpful to have these schema definitions handy without having to juggle running servers that implement them.
 
-> Using Federation? [Skip ahead](<FIXME>) to learn how to register partial schemas with the schema registry
+// TODO: [Add to this section with a brief note about how the schema registry supports registering services under a graph and associating them to partial schemas, with all the same benefits, and an additional one of separating concerns & ownership clearly and tracking compose-ability. This could also be accomplished with a quick note here telling readers to skip forward to the federation section below, and might also benefit in linking back to the `federation` doc that's coming in #504.]
 
 ## Using the Schema Registry
+
+// TODO: [Wherever the setup is for `apollo.config.js`, the assignee should link to it here and update the content there with any changes necessary]
 
 To get started using the schema registry, you'll need to make sure your repository is configured to be an Apollo project.
 
@@ -50,7 +56,9 @@ id      schema        tag
 
 If you're running a distributed GraphQL infrastructure, where GraphQL microservices [compose](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#fetch-service-capabilities) to form a complete schema, there's functionality to register each service's partial schema and still get all of the benefits of the schema registry.
 
-... // TODO
+...
+
+// TODO: [Finish this section and also link to the service list UI page in the `federation` doc from #504. This update or section should also clearly indicate that the `apollo service:push` command also registers the overall schema of the graph **and** writes files to GCS. There's a lot of extra stuff going on here.]
 
 ### Hooking into CI
 
@@ -96,9 +104,13 @@ jobs:
 
 Changes made to your graph's schema over time can be viewed in [Engine](https://engine.apollographql.com) by browsing to the History page for your graph. Each time you push a new version of your schema, it will appear in your graph's history along with a list of the changes introduced in that version.
 
+> Note: TODO -- document that you can only currently see the history of your schema, not of partial schemas
+
 ![Schema history page in the Engine UI](../images/schema-history.png)
 
 ## Managing environments
+
+// [TODO: Question -- should we update these to use a `--variant` option instead? Does that work?]
 
 Product cycles move fast and it's common for schemas to be slightly different across environments as changes make their way through your system. To support this, schemas pushed to the registry can be associated with specific _variants_ of your graph (also referred to _tags_).
 


### PR DESCRIPTION
Specifically, this PR should update the `schema-registry.mdx` file to
illustrate how to use `service:push` with a `--serviceName` flag for
federation and also indicate that it should always be done after a
deployment fully rolls out.