### PR TITLE
op-reg: document lifecycle hooks [AP-562]

### DIFF
--- a/graph-manager-docs/source/operation-registry.mdx
+++ b/graph-manager-docs/source/operation-registry.mdx
@@ -466,7 +466,7 @@ If a problem occurs during the `apollo service:push` command, make sure that the
 
 Additionally, make sure that introspection is enabled on the server since introspection details are used to obtain and publish the schema.
 
-## Migrating from `0.1-alpha.4` to `0.2.0-alpha.1`
+## Migrating from `0.1-alpha.4` to `0.2.x-alpha.x`
 
 ### Summary of changes
 

--- a/graph-manager-docs/source/operation-registry.mdx
+++ b/graph-manager-docs/source/operation-registry.mdx
@@ -326,7 +326,7 @@ The operation registry plugin supports lifecycle methods to improve observabilit
 > Note: this function is **experimental**, since the manifest shape may change
 
 This **experimental** function is run with `newManifest` set to the result returned by polling the source.
-If the manifest is not retrieved on startup, `willUpdateManfiest` is run with `newManifest` set to `undefined`.
+If the manifest is not available on startup due to an outage of Google Cloud Storage, `newManifest` will be `undefined`.
 After the first call, `oldManifest` is set to the existing manifest if one is present.
 
 This **experimental** function can be used to monitor the number of operations in the manifest.
@@ -344,7 +344,6 @@ const server = new ApolloServer({
           newManifest.operations && 
           newManifest.operations.length
         );
-        return newManifest;
       }
     })
   ]

--- a/graph-manager-docs/source/operation-registry.mdx
+++ b/graph-manager-docs/source/operation-registry.mdx
@@ -323,13 +323,13 @@ The operation registry plugin supports lifecycle methods to improve observabilit
 
 #### willUpdateManifest(newManifest?: OperationManifest, oldManifest?: OperationManifest) => void
 
-**Experimental (manifest shape may change)**
+> Note: this function is **experimental**, since the manifest shape may change
 
-This function is run with `newManifest` set to the result returned by polling the source.
+This **experimental** function is run with `newManifest` set to the result returned by polling the source.
 If the manifest is not retrieved on startup, `willUpdateManfiest` is run with `newManifest` set to `undefined`.
 After the first call, `oldManifest` is set to the existing manifest if one is present.
 
-This function can be used to monitor the number of operations in the manifest.
+This **experimental** function can be used to monitor the number of operations in the manifest.
 
 <ExpansionPanel title="Code sample">
 

--- a/graph-manager-docs/source/operation-registry.mdx
+++ b/graph-manager-docs/source/operation-registry.mdx
@@ -319,15 +319,17 @@ const server = new ApolloServer({
 
 ### Lifecycle methods
 
-The operation registry plugin supports three lifecycle methods to improve observability and modify the behavior of safelist: `willUpdateManifest`, `onUnregisteredOperation`, and `onForbiddenOperation`.
+The operation registry plugin supports lifecycle methods to improve observability and modify the behavior of safelist: `willUpdateManifest`, `onUnregisteredOperation`, and `onForbiddenOperation`.
 
-#### willUpdateManifest(newManifest?: OperationManifest, oldManifest?: OperationManifest) => OperationManifest
+#### willUpdateManifest(newManifest?: OperationManifest, oldManifest?: OperationManifest) => void
 
-This function is run with `newManfifest` set to the result from gcs, when new manifest is returned by the poll.
-If the manifest is not retrieved from gcs on startup, `willUpdateManfiest` is run with `newManifest` set to `undefined`.
-Every time the function is called `oldManifest` set to the existing manifest if one is present.
+**Experimental (manifest shape may change)**
 
-This function can be used to monitor the number of operations in the manifest and return a different or fallback manifest.
+This function is run with `newManifest` set to the result returned by polling the source.
+If the manifest is not retrieved on startup, `willUpdateManfiest` is run with `newManifest` set to `undefined`.
+After the first call, `oldManifest` is set to the existing manifest if one is present.
+
+This function can be used to monitor the number of operations in the manifest.
 
 <ExpansionPanel title="Code sample">
 
@@ -338,6 +340,8 @@ const server = new ApolloServer({
       willUpdateManifest(newManifest, oldManifest) {
         metrics.report(
           "safelist.numberOperations",
+          newManifest && 
+          newManifest.operations && 
           newManifest.operations.length
         );
         return newManifest;
@@ -351,7 +355,7 @@ const server = new ApolloServer({
 
 #### onUnregisteredOperation(requestContext)
 
-This function is run when an operation is not found in the safelist.
+This function is run when an operation is not found in the manifest.
 
 <ExpansionPanel title="Code sample">
 
@@ -360,7 +364,7 @@ const server = new ApolloServer({
   plugins: [
     require("apollo-server-plugin-operation-registry")({
       onUnregisteredOperation(requestContext) {
-        metrics.report("safelist.numberUnregisteredOperations", 1);
+        metrics.increment("safelist.numberUnregisteredOperations", 1);
       }
     })
   ]
@@ -371,9 +375,9 @@ const server = new ApolloServer({
 
 #### onForbiddenOperation(requestContext)
 
-This function is run when an operation is not in the safelist and
+This function is run when an operation is not in the manifest and
 `forbidUnregisteredOperations: boolean | (requestContext) => boolean` is
-`true`, ie doesn't accept the operation.
+`true` or returns `true` based on the current request context, ie doesn't accept the operation.
 
 <ExpansionPanel title="Code sample">
 
@@ -383,7 +387,7 @@ const server = new ApolloServer({
     require("apollo-server-plugin-operation-registry")({
       forbidUnregisterdOperations: true,
       onForbiddenOperation(requestContext) {
-        metrics.report("safelist.numberForbiddenOperations", 1);
+        metrics.increment("safelist.numberForbiddenOperations", 1);
       }
     })
   ]

--- a/graph-manager-docs/source/operation-registry.mdx
+++ b/graph-manager-docs/source/operation-registry.mdx
@@ -317,6 +317,81 @@ const server = new ApolloServer({
 
 > _Note:_ The `forbidUnregisteredOperations` callback must be synchronous. If it is necessary to make an `async` request (e.g. a database inquiry) to make a determination about access, such a lookup should occur within the [`context` function](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#constructor-options-lt-ApolloServer-gt) on the `ApolloServer` constructor (or any life-cycle event which has access to `context`) and the result will be available on the `context` of `forbidUnregisteredOperations`.
 
+### Lifecycle methods
+
+The operation registry plugin supports three lifecycle methods to improve observability and modify the behavior of safelist: `willUpdateManifest`, `onUnregisteredOperation`, and `onForbiddenOperation`.
+
+#### willUpdateManifest(newManifest?: OperationManifest, oldManifest?: OperationManifest) => OperationManifest
+
+This function is run with `newManfifest` set to the result from gcs, when new manifest is returned by the poll.
+If the manifest is not retrieved from gcs on startup, `willUpdateManfiest` is run with `newManifest` set to `undefined`.
+Every time the function is called `oldManifest` set to the existing manifest if one is present.
+
+This function can be used to monitor the number of operations in the manifest and return a different or fallback manifest.
+
+<ExpansionPanel title="Code sample">
+
+```js{4-10}
+const server = new ApolloServer({
+  plugins: [
+    require("apollo-server-plugin-operation-registry")({
+      willUpdateManifest(newManifest, oldManifest) {
+        metrics.report(
+          "safelist.numberOperations",
+          newManifest.operations.length
+        );
+        return newManifest;
+      }
+    })
+  ]
+});
+```
+
+</ExpansionPanel>
+
+#### onUnregisteredOperation(requestContext)
+
+This function is run when an operation is not found in the safelist.
+
+<ExpansionPanel title="Code sample">
+
+```js{4-6}
+const server = new ApolloServer({
+  plugins: [
+    require("apollo-server-plugin-operation-registry")({
+      onUnregisteredOperation(requestContext) {
+        metrics.report("safelist.numberUnregisteredOperations", 1);
+      }
+    })
+  ]
+});
+```
+
+</ExpansionPanel>
+
+#### onForbiddenOperation(requestContext)
+
+This function is run when an operation is not in the safelist and
+`forbidUnregisteredOperations: boolean | (requestContext) => boolean` is
+`true`, ie doesn't accept the operation.
+
+<ExpansionPanel title="Code sample">
+
+```js{5-7}
+const server = new ApolloServer({
+  plugins: [
+    require("apollo-server-plugin-operation-registry")({
+      forbidUnregisterdOperations: true,
+      onForbiddenOperation(requestContext) {
+        metrics.report("safelist.numberForbiddenOperations", 1);
+      }
+    })
+  ]
+});
+```
+
+</ExpansionPanel>
+
 ## Testing the plugin
 
 We recommend testing the behavior of the plugin, as well as your `forbidUnregisteredOperations` function, before actually forbidding operation execution in production. To do so, you can use the `dryRun` option, which will log information about the operation in lieu of actually forbidding anything.


### PR DESCRIPTION
This add documentation for the new lifecycle hooks

* willUpdateManifest(newManifest?: OperationManifest, oldManifest?:
OperationManifest) => OperationManifest
  * Run with newManfifest=resultFromGCS when new manifest returned
  from GCS(polled every minute)
  * Run with newManifest=undefined if the manifest is not
  retrieved from gcs on startup
  * oldManifest set to the existing manifest if one is present
* onUnregisteredOperation(requestContext)
  * run when an operation is not found in the safelist
* onForbiddenOperation(requestContext)
  * run when an operation is not in the safelist and
  user-defined override
  (forbidUnregisteredOperations(requestContext) =>
  boolean) doesn't accept the operation