### PR TITLE
Fix headings in operation-registry docs

### DIFF
--- a/docs/source/platform/operation-registry.mdx
+++ b/docs/source/platform/operation-registry.mdx
@@ -120,7 +120,7 @@ Currently, once an operation is registered it will remain registered indefinitel
 
 If you encounter any errors, check the _**Troubleshooting**_ section below.
 
-####3.1 Optionally, set the schema tag
+#### 3.1 Optionally, set the schema tag
 
 To specify the schema tag to register operations on, pass an additional `--tag <TAG>` argument (`npx apollo client:push --tag <TAG>`).
 
@@ -213,7 +213,7 @@ const gateway = new ApolloGateway({
 
 </ExpansionPanel>
 
-####5.1 Optionally, set the schema tag
+#### 5.1 Optionally, set the schema tag
 
 Configure the `schemaTag` field to specify which tag to pull operation manifests from.
 


### PR DESCRIPTION
There are a couple broken headings in the operation registry docs, this adds missing spaces so the MD is interpreted correctly.