### PR TITLE
Hooks conversion

### DIFF
--- a/docs/source/intro/benefits.md
+++ b/docs/source/intro/benefits.md
@@ -84,19 +84,17 @@ const GET_DOGS = gql`
 
 Here, we're describing the shape of the object we want to receive from the server. GraphQL takes care of combining and filtering the data while returning exactly what we ask for.
 
-How do we use this query in our app? Apollo Client builds off of GraphQL's declarative approach to data fetching. In a React app, all of the logic for retrieving your data, tracking loading and error states, and updating your UI is encapsulated in a single `Query` component. This encapsulation makes composing your data fetching components with your presentational components a breeze! Let’s see how to fetch GraphQL data with Apollo Client in a React app:
+How do we use this query in our app? Apollo Client builds off of GraphQL's declarative approach to data fetching. In a React app, all of the logic for retrieving your data, tracking loading and error states, and updating your UI is encapsulated in a single `useQuery` Hook. This encapsulation makes composing your data fetching components with your presentational components a breeze! Let’s see how to fetch GraphQL data with Apollo Client in a React app:
 
 ```jsx
-const Feed = () => (
-  <Query query={GET_DOGS}>
-    {({ loading, error, data }) => {
-      if (error) return <Error />;
-      if (loading || !data) return <Fetching />;
+function Feed() {
+  const { loading, error, data } = useQuery(GET_DOGS);
 
-      return <DogList dogs={data.dogs} />;
-    }}
-  </Query>
-);
+  if (error) return <Error />;
+  if (loading || !data) return <Fetching />;
+
+  return <DogList dogs={data.dogs} />;
+}
 ```
 
 Apollo Client takes care of the request cycle from start to finish, including tracking loading and error states for you. There’s no middleware to set up or boilerplate to write before making your first request, nor do you need to worry about transforming and caching the response. All you have to do is describe the data your component needs and let Apollo Client do the heavy lifting. 💪

--- a/docs/source/intro/benefits.md
+++ b/docs/source/intro/benefits.md
@@ -84,7 +84,7 @@ const GET_DOGS = gql`
 
 Here, we're describing the shape of the object we want to receive from the server. GraphQL takes care of combining and filtering the data while returning exactly what we ask for.
 
-How do we use this query in our app? Apollo Client builds off of GraphQL's declarative approach to data fetching. In a React app, all of the logic for retrieving your data, tracking loading and error states, and updating your UI is encapsulated in a single `useQuery` Hook. This encapsulation makes composing your data fetching components with your presentational components a breeze! Let’s see how to fetch GraphQL data with Apollo Client in a React app:
+How do we use this query in our app? Apollo Client builds off of GraphQL's declarative approach to data fetching. In a React app, all of the logic for retrieving your data, tracking loading and error states, and updating your UI is encapsulated in a single `useQuery` hook. This encapsulation makes composing your data fetching components with your presentational components a breeze! Let’s see how to fetch GraphQL data with Apollo Client in a React app:
 
 ```jsx
 function Feed() {

--- a/docs/source/tutorial/client.md
+++ b/docs/source/tutorial/client.md
@@ -124,7 +124,7 @@ Go ahead and delete the `client.query()` call you just made and the `gql` import
 
 ## Connect your client to React
 
-Connecting Apollo Client to our React app with React Apollo allows us to easily bind GraphQL operations to our UI.
+Connecting Apollo Client to our React app with Apollo's hooks allows us to easily bind GraphQL operations to our UI.
 
 To connect Apollo Client to React, we will wrap our app in the `ApolloProvider` component exported from the `@apollo/react-hooks` package and pass our client to the `client` prop. The `ApolloProvider` component is similar to React’s context provider. It wraps your React app and places the client on the context, which allows you to access it from anywhere in your component tree.
 

--- a/docs/source/tutorial/client.md
+++ b/docs/source/tutorial/client.md
@@ -147,4 +147,4 @@ ReactDOM.render(
 );
 ```
 
-Now, we're ready to start building our first `useQuery` Hook based component in the next section.
+Now, we're ready to start building our first component with the `useQuery` hook in the next section.

--- a/docs/source/tutorial/client.md
+++ b/docs/source/tutorial/client.md
@@ -124,16 +124,16 @@ Go ahead and delete the `client.query()` call you just made and the `gql` import
 
 ## Connect your client to React
 
-Connecting Apollo Client to our React app with `react-apollo` allows us to easily bind GraphQL operations to our UI.
+Connecting Apollo Client to our React app with React Apollo allows us to easily bind GraphQL operations to our UI.
 
-To connect Apollo Client to React, we will wrap our app in the `ApolloProvider` component exported from the `react-apollo` package and pass our client to the `client` prop. The `ApolloProvider` component is similar to React’s context provider. It wraps your React app and places the client on the context, which allows you to access it from anywhere in your component tree.
+To connect Apollo Client to React, we will wrap our app in the `ApolloProvider` component exported from the `@apollo/react-hooks` package and pass our client to the `client` prop. The `ApolloProvider` component is similar to React’s context provider. It wraps your React app and places the client on the context, which allows you to access it from anywhere in your component tree.
 
 Open `src/index.js` and add the following lines of code:
 
 _src/index.js_
 
-```jsx{1,4,6}
-import { ApolloProvider } from 'react-apollo';
+```jsx
+import { ApolloProvider } from '@apollo/react-hooks';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Pages from './pages';
@@ -147,4 +147,4 @@ ReactDOM.render(
 );
 ```
 
-Now, we're ready to start building our first `Query` components in the next section.
+Now, we're ready to start building our first `useQuery` Hook based component in the next section.

--- a/docs/source/tutorial/local-state.md
+++ b/docs/source/tutorial/local-state.md
@@ -263,7 +263,7 @@ const StyledButton = styled('button')(menuItemClassName, {
 
 When we click the button, we perform a direct cache write by calling `client.writeData` and passing in a data object that sets the `isLoggedIn` boolean to false.
 
-We can also perform direct writes within the `update` function of the `useMutation` Hook. The `update` function allows us to manually update the cache after a mutation occurs without refetching data. Let's look at an example in `src/containers/book-trips.js`:
+We can also perform direct writes within the `update` function of the `useMutation` hook. The `update` function allows us to manually update the cache after a mutation occurs without refetching data. Let's look at an example in `src/containers/book-trips.js`:
 
 _src/containers/book-trips.js_
 

--- a/docs/source/tutorial/local-state.md
+++ b/docs/source/tutorial/local-state.md
@@ -416,7 +416,7 @@ export default function ActionButton({ isBooked, id, isInCart }) {
 }
 ```
 
-In this example, we're using the `isBooked` prop passed into the component to determine which mutation we should fire. Just like remote mutations, we can pass in our local mutations to the same `useMutation` Hook.
+In this example, we're using the `isBooked` prop passed into the component to determine which mutation we should fire. Just like remote mutations, we can pass in our local mutations to the same `useMutation` hook.
 
 ---
 

--- a/docs/source/tutorial/local-state.md
+++ b/docs/source/tutorial/local-state.md
@@ -231,26 +231,23 @@ _src/containers/logout-button.js_
 ```jsx
 import React from 'react';
 import styled from 'react-emotion';
-import { ApolloConsumer } from '@apollo/react-hooks';
+import { useApolloClient } from '@apollo/react-hooks';
 
 import { menuItemClassName } from '../components/menu-item';
 import { ReactComponent as ExitIcon } from '../assets/icons/exit.svg';
 
 export default function LogoutButton() {
+  const client = useApolloClient();
   return (
-    <ApolloConsumer>
-      {client => (
-        <StyledButton
-          onClick={() => {
-            client.writeData({ data: { isLoggedIn: false } }); // highlight-line
-            localStorage.clear();
-          }}
-        >
-          <ExitIcon />
-          Logout
-        </StyledButton>
-      )}
-    </ApolloConsumer>
+    <StyledButton
+      onClick={() => {
+        client.writeData({ data: { isLoggedIn: false } }); // highlight-line
+        localStorage.clear();
+      }}
+    >
+      <ExitIcon />
+      Logout
+    </StyledButton>
   );
 }
 

--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -9,7 +9,7 @@ With Apollo Client, updating data from a graph API is as simple as calling a fun
 
 ## What is the useMutation hook?
 
-The `useMutation` Hook is another important building block in an Apollo app. It leverages React's [Hooks API](https://reactjs.org/docs/hooks-intro.html) to provide a function to execute a GraphQL mutation. Additionally, it tracks the loading, completion, and error state of that mutation.
+The `useMutation` hook is another important building block in an Apollo app. It leverages React's [Hooks API](https://reactjs.org/docs/hooks-intro.html) to provide a function to execute a GraphQL mutation. Additionally, it tracks the loading, completion, and error state of that mutation.
 
 Updating data with a `useMutation` Hook from `@apollo/react-hooks` is very similar to fetching data with a `useQuery` Hook. The main difference is that the first value in the `useMutation` result tuple is a **mutate function** that actually triggers the mutation when it is called. The second value in the result tuple is a result object that contains loading and error state, as well as the return value from the mutation. Let's see an example:
 

--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -33,7 +33,7 @@ const LOGIN_USER = gql`
 `;
 ```
 
-Just like before, we're using the `gql` function to wrap our GraphQL mutation so it can be parsed into an AST. We're also importing some components that we'll use in the next steps. Now, let's bind this mutation to our component by passing it to the `useMutation` Hook:
+Just like before, we're using the `gql` function to wrap our GraphQL mutation so it can be parsed into an AST. We're also importing some components that we'll use in the next steps. Now, let's bind this mutation to our component by passing it to the `useMutation` hook:
 
 _src/pages/login.js_
 

--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -44,7 +44,7 @@ export default function Login() {
 }
 ```
 
-Our `useMutation` Hook returns a mutate function (`login`) and the data object returned from the mutation. Finally, we pass our login function to the `LoginForm` component.
+Our `useMutation` hook returns a mutate function (`login`) and the data object returned from the mutation that we destructure from the tuple. Finally, we pass our login function to the `LoginForm` component.
 
 To create a better experience for our users, we want to persist the login between sessions. In order to do that, we need to save our login token to `localStorage`. Let's learn how we can use the `onCompleted` handler of `useMutation` to persist our login:
 

--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -21,7 +21,7 @@ _src/pages/login.js_
 
 ```js
 import React from 'react';
-import { ApolloConsumer, useMutation } from '@apollo/react-hooks';
+import { useApolloClient, useMutation } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 
 import { LoginForm, Loading } from '../components';
@@ -48,18 +48,19 @@ Our `useMutation` hook returns a mutate function (`login`) and the data object r
 
 To create a better experience for our users, we want to persist the login between sessions. In order to do that, we need to save our login token to `localStorage`. Let's learn how we can use the `onCompleted` handler of `useMutation` to persist our login:
 
-### Expose Apollo Client with ApolloConsumer
+### Expose Apollo Client with useApolloClient
 
-One of the main functions of React Apollo is that it puts your `ApolloClient` instance on React's context. Sometimes, we need to access the `ApolloClient` instance to directly call a method that isn't exposed by the `@apollo/react-hooks` helper components. The `ApolloConsumer` component can help us access the client.
+One of the main functions of React Apollo is that it puts your `ApolloClient` instance on React's context. Sometimes, we need to access the `ApolloClient` instance to directly call a method that isn't exposed by the `@apollo/react-hooks` helper components. The `useApolloClient` hook can help us access the client.
 
-`ApolloConsumer` takes a render prop function as a child that is called with the client instance. Let's wrap our `useMutation` based component with `ApolloConsumer` to expose the client. Next, we want to pass an `onCompleted` callback to `useMutation` that will be called once the mutation is complete with its return value. This callback is where we will save the login token to `localStorage`.
+Let's call `useApolloClient` to get the currently configured client instance. Next, we want to pass an `onCompleted` callback to `useMutation` that will be called once the mutation is complete with its return value. This callback is where we will save the login token to `localStorage`.
 
 In our `onCompleted` handler, we also call `client.writeData` to write local data to the Apollo cache indicating that the user is logged in. This is an example of a **direct write** that we'll explore further in the next section on local state management.
 
 _src/pages/login.js_
 
-```jsx{5-8,13-14,22}
+```jsx{2,6-9}
 export default function Login() {
+  const client = useApolloClient();
   const [login, { loading, error }] = useMutation(
     LOGIN_USER,
     {
@@ -70,18 +71,10 @@ export default function Login() {
     }
   );
 
-  return (
-    <ApolloConsumer>
-      {client => {
-        // this loading state will probably never show, but it's helpful to
-        // have for testing
-        if (loading) return <Loading />;
-        if (error) return <p>An error occurred</p>;
+  if (loading) return <Loading />;
+  if (error) return <p>An error occurred</p>;
 
-        return <LoginForm login={login} />;
-      }}
-    </ApolloConsumer>
-  );
+  return <LoginForm login={login} />;
 }
 ```
 

--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -11,7 +11,7 @@ With Apollo Client, updating data from a graph API is as simple as calling a fun
 
 The `useMutation` hook is another important building block in an Apollo app. It leverages React's [Hooks API](https://reactjs.org/docs/hooks-intro.html) to provide a function to execute a GraphQL mutation. Additionally, it tracks the loading, completion, and error state of that mutation.
 
-Updating data with a `useMutation` Hook from `@apollo/react-hooks` is very similar to fetching data with a `useQuery` Hook. The main difference is that the first value in the `useMutation` result tuple is a **mutate function** that actually triggers the mutation when it is called. The second value in the result tuple is a result object that contains loading and error state, as well as the return value from the mutation. Let's see an example:
+Updating data with a `useMutation` hook from `@apollo/react-hooks` is very similar to fetching data with a `useQuery` hook. The main difference is that the first value in the `useMutation` result tuple is a **mutate function** that actually triggers the mutation when it is called. The second value in the result tuple is a result object that contains loading and error state, as well as the return value from the mutation. Let's see an example:
 
 ## Update data with useMutation
 

--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -5,7 +5,7 @@ description: Learn how to update data with the useMutation hook
 
 Time to accomplish: _12 Minutes_
 
-With Apollo Client, updating data from a graph API is as simple as calling a function. Additionally, the Apollo Client cache is smart enough to automatically update in most cases. In this section, we'll learn how to use the `useMutation` Hook from React Apollo to login a user.
+With Apollo Client, updating data from a graph API is as simple as calling a function. Additionally, the Apollo Client cache is smart enough to automatically update in most cases. In this section, we'll learn how to use the `useMutation` hook to login a user.
 
 ## What is the useMutation hook?
 

--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -7,7 +7,7 @@ Time to accomplish: _12 Minutes_
 
 With Apollo Client, updating data from a graph API is as simple as calling a function. Additionally, the Apollo Client cache is smart enough to automatically update in most cases. In this section, we'll learn how to use the `useMutation` Hook from React Apollo to login a user.
 
-## What is the useMutation Hook?
+## What is the useMutation hook?
 
 The `useMutation` Hook is another important building block in an Apollo app. It leverages React's [Hooks API](https://reactjs.org/docs/hooks-intro.html) to provide a function to execute a GraphQL mutation. Additionally, it tracks the loading, completion, and error state of that mutation.
 

--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -1,19 +1,19 @@
 ---
 title: '7. Update data with mutations'
-description: Learn how to update data with the Mutation component
+description: Learn how to update data with the useMutation Hook
 ---
 
 Time to accomplish: _12 Minutes_
 
-With Apollo Client, updating data from a graph API is as simple as calling a function. Additionally, the Apollo Client cache is smart enough to automatically update in most cases. In this section, we'll learn how to use the `Mutation` component from `react-apollo` to login a user.
+With Apollo Client, updating data from a graph API is as simple as calling a function. Additionally, the Apollo Client cache is smart enough to automatically update in most cases. In this section, we'll learn how to use the `useMutation` Hook from React Apollo to login a user.
 
-## What is a Mutation component?
+## What is the useMutation Hook?
 
-The `Mutation` component is another important building block in an Apollo app. It's a React component that provides a function to execute a GraphQL mutation. Additionally, it tracks the loading, completion, and error state of that mutation.
+The `useMutation` Hook is another important building block in an Apollo app. It leverages React's [Hooks API](https://reactjs.org/docs/hooks-intro.html) to provide a function to execute a GraphQL mutation. Additionally, it tracks the loading, completion, and error state of that mutation.
 
-Updating data with a `Mutation` component from `react-apollo` is very similar to fetching data with a `Query` component. The main difference is that the first argument to the `Mutation` render prop function is a **mutate function** that actually triggers the mutation when it is called. The second argument to the `Mutation` render prop function is a result object that contains loading and error state, as well as the return value from the mutation. Let's see an example:
+Updating data with a `useMutation` Hook from `@apollo/react-hooks` is very similar to fetching data with a `useQuery` Hook. The main difference is that the first value in the `useMutation` result tuple is a **mutate function** that actually triggers the mutation when it is called. The second value in the result tuple is a result object that contains loading and error state, as well as the return value from the mutation. Let's see an example:
 
-## Update data with Mutation
+## Update data with useMutation
 
 The first step is defining our GraphQL mutation. To start, navigate to `src/pages/login.js` and copy the code below so we can start building out the login screen:
 
@@ -21,7 +21,7 @@ _src/pages/login.js_
 
 ```js
 import React from 'react';
-import { Mutation, ApolloConsumer } from 'react-apollo';
+import { ApolloConsumer, useMutation } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 
 import { LoginForm, Loading } from '../components';
@@ -33,56 +33,53 @@ const LOGIN_USER = gql`
 `;
 ```
 
-Just like before, we're using the `gql` function to wrap our GraphQL mutation so it can be parsed into an AST. We're also importing some components that we'll use in the next steps. Now, let's bind this mutation to our component by passing it to the `mutation` prop:
+Just like before, we're using the `gql` function to wrap our GraphQL mutation so it can be parsed into an AST. We're also importing some components that we'll use in the next steps. Now, let's bind this mutation to our component by passing it to the `useMutation` Hook:
 
 _src/pages/login.js_
 
 ```jsx
 export default function Login() {
-  return (
-    <Mutation mutation={LOGIN_USER}>
-      {(login, { data }) => <LoginForm login={login} />}
-    </Mutation>
-  );
+  const [login, { data }] = useMutation(LOGIN_USER);
+  return <LoginForm login={login} />;
 }
 ```
 
-Our `Mutation` component takes a render prop function as a child that exposes a mutate function (`login`) and the data object returned from the mutation. Finally, we pass our login function to the `LoginForm` component.
+Our `useMutation` Hook returns a mutate function (`login`) and the data object returned from the mutation. Finally, we pass our login function to the `LoginForm` component.
 
-To create a better experience for our users, we want to persist the login between sessions. In order to do that, we need to save our login token to `localStorage`. Let's learn how we can use the `onCompleted` handler on `Mutation` to persist our login:
+To create a better experience for our users, we want to persist the login between sessions. In order to do that, we need to save our login token to `localStorage`. Let's learn how we can use the `onCompleted` handler of `useMutation` to persist our login:
 
 ### Expose Apollo Client with ApolloConsumer
 
-One of the main functions of `react-apollo` is that it puts your `ApolloClient` instance on React's context. Sometimes, we need to access the `ApolloClient` instance to directly call a method that isn't exposed by the `react-apollo` helper components. The `ApolloConsumer` component can help us access the client.
+One of the main functions of React Apollo is that it puts your `ApolloClient` instance on React's context. Sometimes, we need to access the `ApolloClient` instance to directly call a method that isn't exposed by the `@apollo/react-hooks` helper components. The `ApolloConsumer` component can help us access the client.
 
-`ApolloConsumer` takes a render prop function as a child that is called with the client instance. Let's wrap our `Mutation` component with `ApolloConsumer` to expose the client. Next, we want to pass an `onCompleted` callback to `Mutation` that will be called once the mutation is complete with its return value. This callback is where we will save the login token to `localStorage`.
+`ApolloConsumer` takes a render prop function as a child that is called with the client instance. Let's wrap our `useMutation` based component with `ApolloConsumer` to expose the client. Next, we want to pass an `onCompleted` callback to `useMutation` that will be called once the mutation is complete with its return value. This callback is where we will save the login token to `localStorage`.
 
 In our `onCompleted` handler, we also call `client.writeData` to write local data to the Apollo cache indicating that the user is logged in. This is an example of a **direct write** that we'll explore further in the next section on local state management.
 
 _src/pages/login.js_
 
-```jsx{3,4,7-10,22}
+```jsx{5-8,13-14,22}
 export default function Login() {
+  const [login, { loading, error }] = useMutation(
+    LOGIN_USER,
+    {
+      onCompleted({ login }) {
+        localStorage.setItem('token', login);
+        client.writeData({ data: { isLoggedIn: true } });
+      }
+    }
+  );
+
   return (
     <ApolloConsumer>
-      {client => (
-        <Mutation
-          mutation={LOGIN_USER}
-          onCompleted={({ login }) => {
-            localStorage.setItem('token', login);
-            client.writeData({ data: { isLoggedIn: true } });
-          }}
-        >
-          {(login, { loading, error }) => {
-            // this loading state will probably never show, but it's helpful to
-            // have for testing
-            if (loading) return <Loading />;
-            if (error) return <p>An error occurred</p>;
+      {client => {
+        // this loading state will probably never show, but it's helpful to
+        // have for testing
+        if (loading) return <Loading />;
+        if (error) return <p>An error occurred</p>;
 
-            return <LoginForm login={login} />;
-          }}
-        </Mutation>
-      )}
+        return <LoginForm login={login} />;
+      }}
     </ApolloConsumer>
   );
 }

--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -1,6 +1,6 @@
 ---
 title: '7. Update data with mutations'
-description: Learn how to update data with the useMutation Hook
+description: Learn how to update data with the useMutation hook
 ---
 
 Time to accomplish: _12 Minutes_

--- a/docs/source/tutorial/queries.md
+++ b/docs/source/tutorial/queries.md
@@ -78,7 +78,7 @@ export default function Launches() {
 }
 ```
 
-To render the list, we pass the `GET_LAUNCHES` query from the previous step into our `useQuery` Hook. Then, depending on the state of `loading`, `error`, and `data`, we either render a loading indicator, an error message, or a list of launches.
+To render the list, we pass the `GET_LAUNCHES` query from the previous step into our `useQuery` hook. Then, depending on the state of `loading`, `error`, and `data`, we either render a loading indicator, an error message, or a list of launches.
 
 We're not done yet! Right now, this query is only fetching the first 20 launches from the list. To fetch the full list of launches, we need to build a pagination feature that displays a `Load More` button for loading more items on the screen. Let's learn how!
 

--- a/docs/source/tutorial/queries.md
+++ b/docs/source/tutorial/queries.md
@@ -7,7 +7,7 @@ description: Learn how to fetch data with the useQuery hook
 
 Apollo Client simplifies fetching data from a graph API because it intelligently caches your data, as well as tracks loading and error state. In the previous section, we learned how to fetch a sample query with Apollo Client without using a view integration. In this section, we'll learn how to use the `useQuery` Hook from `@apollo/react-hooks` to fetch more complex queries and execute features like pagination.
 
-## The useQuery Hook
+## The useQuery hook
 
 The `useQuery` Hook is one of the most important building blocks of an Apollo app. It's a React Hook that fetches a GraphQL query and exposes the result so you can render your UI based on the data it returns.
 

--- a/docs/source/tutorial/queries.md
+++ b/docs/source/tutorial/queries.md
@@ -9,7 +9,7 @@ Apollo Client simplifies fetching data from a graph API because it intelligently
 
 ## The useQuery hook
 
-The `useQuery` Hook is one of the most important building blocks of an Apollo app. It's a React Hook that fetches a GraphQL query and exposes the result so you can render your UI based on the data it returns.
+The `useQuery` hook is one of the most important building blocks of an Apollo app. It's a React Hook that fetches a GraphQL query and exposes the result so you can render your UI based on the data it returns.
 
 The `useQuery` Hook leverages React's [Hooks API](https://reactjs.org/docs/hooks-intro.html) to fetch and load data from queries into our UI. It exposes `error`, `loading` and `data` properties through a result object, that help us populate and render our component. Let's see an example:
 

--- a/docs/source/tutorial/queries.md
+++ b/docs/source/tutorial/queries.md
@@ -274,7 +274,7 @@ Great, now we've successfully refactored our queries to use fragments. Fragments
 
 ### Customizing the fetch policy
 
-Sometimes, it's useful to tell Apollo Client to bypass the cache altogether if you have some data that constantly needs to be refreshed. We can do this by customizing the `useQuery` Hook's `fetchPolicy`.
+Sometimes, it's useful to tell Apollo Client to bypass the cache altogether if you have some data that constantly needs to be refreshed. We can do this by customizing the `useQuery` hook's `fetchPolicy`.
 
 First, let's navigate to `src/pages/profile.js` and write our query:
 

--- a/docs/source/tutorial/queries.md
+++ b/docs/source/tutorial/queries.md
@@ -11,7 +11,7 @@ Apollo Client simplifies fetching data from a graph API because it intelligently
 
 The `useQuery` hook is one of the most important building blocks of an Apollo app. It's a React Hook that fetches a GraphQL query and exposes the result so you can render your UI based on the data it returns.
 
-The `useQuery` Hook leverages React's [Hooks API](https://reactjs.org/docs/hooks-intro.html) to fetch and load data from queries into our UI. It exposes `error`, `loading` and `data` properties through a result object, that help us populate and render our component. Let's see an example:
+The `useQuery` hook leverages React's [Hooks API](https://reactjs.org/docs/hooks-intro.html) to fetch and load data from queries into our UI. It exposes `error`, `loading` and `data` properties through a result object, that help us populate and render our component. Let's see an example:
 
 ## Fetching a list
 

--- a/docs/source/tutorial/queries.md
+++ b/docs/source/tutorial/queries.md
@@ -5,7 +5,7 @@ description: Learn how to fetch data with the useQuery hook
 
  Time to accomplish: _15 Minutes_
 
-Apollo Client simplifies fetching data from a graph API because it intelligently caches your data, as well as tracks loading and error state. In the previous section, we learned how to fetch a sample query with Apollo Client without using a view integration. In this section, we'll learn how to use the `useQuery` Hook from `@apollo/react-hooks` to fetch more complex queries and execute features like pagination.
+Apollo Client simplifies fetching data from a graph API because it intelligently caches your data, as well as tracks loading and error state. In the previous section, we learned how to fetch a sample query with Apollo Client without using a view integration. In this section, we'll learn how to use the `useQuery` hook from `@apollo/react-hooks` to fetch more complex queries and execute features like pagination.
 
 ## The useQuery hook
 

--- a/docs/source/tutorial/queries.md
+++ b/docs/source/tutorial/queries.md
@@ -1,6 +1,6 @@
 ---
 title: "6. Fetch data with queries"
-description: Learn how to fetch data with the useQuery Hook
+description: Learn how to fetch data with the useQuery hook
 ---
 
  Time to accomplish: _15 Minutes_


### PR DESCRIPTION
This PR updates the tutorial and platform parts of the docs to use Hooks, instead of render prop components. This work should not be merged until RA 3 is launched, and the following have also been merged:

- https://github.com/apollographql/fullstack-tutorial/pull/93
- https://github.com/apollographql/apollo-client/pull/5119