### PR TITLE
Remove all references to Zeit Now

### DIFF
--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -7,7 +7,7 @@ Time to accomplish: _15 Minutes_
 
 Great job for making it this far! We've already learned how to build a GraphQL API with Apollo, connect it to REST and SQL data sources, and send GraphQL queries. Now that we've completed building our graph, it's finally time to deploy it! 🎉
 
-An Apollo GraphQL API can be deployed to any cloud service, such as Heroku, AWS Lambda, or Netlify. In this tutorial, we'll deploy our graph API to [Zeit Now](https://zeit.co/now). You will need to create a [_Now_ account](https://zeit.co/signup) in order to follow these steps. If you haven't already created an [Apollo Engine](https://engine.apollographql.com/) account, you will need to sign up for one.
+An Apollo GraphQL API can be deployed to any cloud service, such as Heroku, AWS Lambda, or Netlify. If you haven't already created an [Apollo Engine](https://engine.apollographql.com/) account, you will need to sign up for one.
 
 ## Publish your schema to Engine
 


### PR DESCRIPTION
In #444 the section on deploying the app was removed, but the section on signing up for Zeit was missed. This means people following the tutorial will create an account for no reason. This PR removes that reference.