### PR TITLE
Typo fix: `Mutation` instead of `Mission` in resolvers.md

### DIFF
--- a/docs/source/tutorial/resolvers.md
+++ b/docs/source/tutorial/resolvers.md
@@ -263,7 +263,7 @@ _src/schema.js_
 
 The first argument passed into our resolver is the parent, which refers to the mission object. The second argument is the size we pass to our `missionPatch` field, which we use to determine which property on the mission object we want our field to resolve to.
 
-Now that we know how to add resolvers on types other than `Query` and `Mutation`, let's add some more resolvers to the `Launch` and `User` types. Copy this code into your resolver map:
+Now that we know how to add resolvers on types other than `Query` and `Mission`, let's add some more resolvers to the `Launch` and `User` types. Copy this code into your resolver map:
 
 _src/resolvers.js_
 


### PR DESCRIPTION
Line 266 says that "we know how to add resolvers on types other than `Query` and `Mutation`", but the tutorial hasn't touched Mutation resolvers so far. The Mutation resolvers are in line 332

I highly suspect the author meant to write "Mission" as that was the last type visited in the tutorial