### PR TITLE
Content edit for docs landing page and Graph Manager overview

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -21,10 +21,9 @@ module.exports = {
             'tutorial/queries',
             'tutorial/mutations',
             'tutorial/local-state',
-            // 'tutorial/whats-next'
           ],
-          Platform: [
-            'references/apollo-engine',
+          'Apollo Graph Manager': [
+            'platform/graph-manager-overview',
             'platform/schema-registry',
             'platform/schema-validation',
             'platform/client-awareness',
@@ -42,6 +41,7 @@ module.exports = {
           References: [
             'references/apollo-config',
             'references/setup-analytics',
+            'references/apollo-engine',
             'references/engine-proxy',
             'references/engine-proxy-release-notes',
           ],

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -41,7 +41,7 @@ module.exports = {
           References: [
             'references/apollo-config',
             'references/setup-analytics',
-            'references/apollo-engine',
+            'references/graph-manager-data-privacy',
             'references/engine-proxy',
             'references/engine-proxy-release-notes',
           ],

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -20,10 +20,11 @@ module.exports = {
             'tutorial/client',
             'tutorial/queries',
             'tutorial/mutations',
-            'tutorial/local-state'
+            'tutorial/local-state',
             // 'tutorial/whats-next'
           ],
           Platform: [
+            'references/apollo-engine',
             'platform/schema-registry',
             'platform/schema-validation',
             'platform/client-awareness',
@@ -31,22 +32,21 @@ module.exports = {
             'platform/editor-plugins',
             'platform/performance',
             'platform/integrations',
-            'platform/federation'
+            'platform/federation',
           ],
           Resources: [
             '[Principled GraphQL](https://principledgraphql.com)',
             'resources/graphql-glossary',
-            'resources/faq'
+            'resources/faq',
           ],
           References: [
             'references/apollo-config',
-	          'references/setup-analytics',
-            'references/apollo-engine',
+            'references/setup-analytics',
             'references/engine-proxy',
-            'references/engine-proxy-release-notes'
-          ]
-        }
-      }
-    }
-  ]
+            'references/engine-proxy-release-notes',
+          ],
+        },
+      },
+    },
+  ],
 };

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -1,26 +1,30 @@
 ---
-title: Welcome
-description: Start here to learn about the Apollo platform
+title: Welcome to the Apollo Docs
 ---
 
-Welcome! 👋 We're excited you're here to learn about Apollo.
+Hi there! 👋 We're excited you're here to learn about Apollo.
 
-The Apollo GraphQL platform is an implementation of GraphQL that helps you manage data from the cloud to your UI. It's incrementally adoptable and can be layered over your existing services, including REST APIs and databases. Apollo includes two open-source libraries for the client and server, in addition to developer tooling that provides everything you need to run a graph API in production with confidence.
+The Apollo platform is a complete, GraphQL-based solution for managing the transmission of data between application clients (such as React and iOS apps) and back-end services.
 
-import {ButtonWrapper, ButtonLink} from 'gatsby-theme-apollo-docs';
+It's easy to adopt Apollo incrementally, meaning you can set it up alongside an existing solution (such as a REST API) and migrate functionality at your convenience.
+
+**The Apollo platform consists of:**
+
+- **Apollo Client**, an <a href="https://github.com/apollographql/apollo-client" target="_blank">open-source library</a> for transmitting GraphQL operations from an application client to a back-end server
+
+- **Apollo Server**, an <a href="https://github.com/apollographql/apollo-server" target="_blank">open-source library</a> for receiving, executing, and responding to GraphQL operations from application clients
+
+- **Apollo Graph Manager**, a <a href="https://engine.apollographql.com" target="_blank">cloud service</a> that helps you manage, validate, and secure your organization's entire data graph
+
+Conveniently, we have a tutorial that introduces you to all of these components. Ready to dive in?
+
+import { ButtonWrapper, ButtonLink } from 'gatsby-theme-apollo-docs';
 
 <ButtonWrapper>
-  <ButtonLink
-    size="large"
-    color="branded"
-    to="/tutorial/introduction"
-  >
+  <ButtonLink size="large" color="branded" to="/tutorial/introduction">
     Try it out!
   </ButtonLink>
-  <ButtonLink
-    size="large"
-    to="/intro/platform"
-  >
+  <ButtonLink size="large" to="/intro/platform">
     Learn more
   </ButtonLink>
 </ButtonWrapper>

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -11,13 +11,13 @@ It's easy to adopt Apollo incrementally, meaning you can set it up alongside an 
 
 **The Apollo platform consists of:**
 
-- [Apollo Client](/docs/react/), an open-source library for managing state in application clients
+- [Apollo Client](/react/), an open-source library for managing state in application clients
 
-- [Apollo Server](/docs/apollo-server), an open-source framework for implementing and running a data graph at scale
+- [Apollo Server](/apollo-server), an open-source framework for implementing and running a data graph at scale
 
-- [Apollo Graph Manager](/references/apollo-engine) (formerly Engine), a cloud service that helps you manage, validate, and secure your organization's data graph
+- [Apollo Graph Manager](/platform/graph-manager-overview) (formerly Engine), a cloud service that helps you manage, validate, and secure your organization's data graph
 
-- Developer tools that make it even easier to work with Apollo, including extensions for [Chrome](/docs/react/features/developer-tooling/#apollo-client-devtools) and [VS Code](/docs/platform/editor-plugins/)
+- Developer tools that make it even easier to work with Apollo, including extensions for [Chrome](/react/features/developer-tooling/#apollo-client-devtools) and [VS Code](/platform/editor-plugins/)
 
 Conveniently, we have a tutorial that introduces you to each component of the platform. Ready to dive in?
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -15,7 +15,7 @@ It's easy to adopt Apollo incrementally, meaning you can set it up alongside an 
 
 - [Apollo Server](/docs/apollo-server), an open-source framework for implementing and running a data graph at scale
 
-- [Apollo Graph Manager](/references/apollo-engine), a cloud service that helps you manage, validate, and secure your organization's data graph
+- [Apollo Graph Manager](/references/apollo-engine) (formerly Engine), a cloud service that helps you manage, validate, and secure your organization's data graph
 
 - Developer tools that make it even easier to work with Apollo, including extensions for [Chrome](/docs/react/features/developer-tooling/#apollo-client-devtools) and [VS Code](/docs/platform/editor-plugins/)
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -11,13 +11,13 @@ It's easy to adopt Apollo incrementally, meaning you can set it up alongside an 
 
 **The Apollo platform consists of:**
 
-- [Apollo Client](/react/), an open-source library for managing state in application clients
+- [Apollo Client](https://apollographql.com/docs/react/), an open-source library for managing state in application clients
 
-- [Apollo Server](/apollo-server), an open-source framework for implementing and running a data graph at scale
+- [Apollo Server](https://apollographql.com/docs/apollo-server/), an open-source framework for implementing and running a data graph at scale
 
-- [Apollo Graph Manager](/platform/graph-manager-overview) (formerly Engine), a cloud service that helps you manage, validate, and secure your organization's data graph
+- [Apollo Graph Manager](https://apollographql.com/docs/platform/graph-manager-overview) (formerly Engine), a cloud service that helps you manage, validate, and secure your organization's data graph
 
-- Developer tools that make it even easier to work with Apollo, including extensions for [Chrome](/react/features/developer-tooling/#apollo-client-devtools) and [VS Code](/platform/editor-plugins/)
+- Developer tools that make it even easier to work with Apollo, including extensions for [Chrome](https://apollographql.com/docs/react/features/developer-tooling/#apollo-client-devtools) and [VS Code](/platform/editor-plugins/)
 
 Conveniently, we have a tutorial that introduces you to each component of the platform. Ready to dive in?
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -1,22 +1,25 @@
 ---
-title: Welcome to the Apollo Docs
+title: Welcome
+description: Start here to learn about the Apollo platform
 ---
 
 Hi there! 👋 We're excited you're here to learn about Apollo.
 
-The Apollo platform is a complete, GraphQL-based solution for managing the transmission of data between application clients (such as React and iOS apps) and back-end services.
+Apollo is a platform for building a **data graph**, a communication layer that seamlessly connects application clients (such as React and iOS apps) to back-end services.
 
 It's easy to adopt Apollo incrementally, meaning you can set it up alongside an existing solution (such as a REST API) and migrate functionality at your convenience.
 
 **The Apollo platform consists of:**
 
-- **Apollo Client**, an <a href="https://github.com/apollographql/apollo-client" target="_blank">open-source library</a> for transmitting GraphQL operations from an application client to a back-end server
+- [Apollo Client](/docs/react/), an open-source library for managing state in application clients
 
-- **Apollo Server**, an <a href="https://github.com/apollographql/apollo-server" target="_blank">open-source library</a> for receiving, executing, and responding to GraphQL operations from application clients
+- [Apollo Server](/docs/apollo-server), an open-source framework for implementing and running a data graph at scale
 
-- **Apollo Graph Manager**, a <a href="https://engine.apollographql.com" target="_blank">cloud service</a> that helps you manage, validate, and secure your organization's entire data graph
+- [Apollo Graph Manager](/references/apollo-engine), a cloud service that helps you manage, validate, and secure your organization's data graph
 
-Conveniently, we have a tutorial that introduces you to all of these components. Ready to dive in?
+- Developer tools that make it even easier to work with Apollo, including extensions for [Chrome](/docs/react/features/developer-tooling/#apollo-client-devtools) and [VS Code](/docs/platform/editor-plugins/)
+
+Conveniently, we have a tutorial that introduces you to each component of the platform. Ready to dive in?
 
 import { ButtonWrapper, ButtonLink } from 'gatsby-theme-apollo-docs';
 

--- a/docs/source/platform/graph-manager-overview.md
+++ b/docs/source/platform/graph-manager-overview.md
@@ -131,7 +131,7 @@ You can delete a graph from Graph Manager by visiting its Settings page and clic
 Every graph in Graph Manager should correspond to a single application. However, a single
 application might run in multiple _environments_ (such as test, staging, and production).
 
-To distinguish between graph activity for different application environments, you can define [**variants**](/platform/schema-registry.html#schema-tags) for a graph. Each variant has its own schema
+To distinguish between graph activity for different application environments, you can define [**variants**](https://www.apollographql.com/docs/platform/schema-registry/#managing-environments) for a graph. Each variant has its own schema
 that can (but doesn't have to) differ from the default variant.
 
 When your server sends metrics to Graph Manager, it can associate an operation with
@@ -143,7 +143,7 @@ each application environment in isolation.
 Graph Manager ingests and stores performance metrics data sent from your GraphQL server.
 Use one of the following methods to send data to Graph Manager:
 
-* Use [Apollo Server](/apollo-server/) as your application's GraphQL server and [include a Graph Manager API key](/tutorial/production/#get-an-engine-api-key) in your server configuration.
+* Use [Apollo Server](https://www.apollographql.com/docs/apollo-server/) as your application's GraphQL server and [include a Graph Manager API key](/tutorial/production/#get-an-engine-api-key) in your server configuration.
 
 * If you aren't using Apollo Server, you can send trace metrics to the [Graph Manager reporting endpoint](/references/setup-analytics/#engine-reporting-endpoint) (again,
 providing an API key with every request).

--- a/docs/source/platform/graph-manager-overview.md
+++ b/docs/source/platform/graph-manager-overview.md
@@ -1,0 +1,159 @@
+---
+title: Overview
+description: Learn about Graph Manager features and create your account
+---
+
+Apollo Graph Manager (formerly Apollo Engine) is a cloud service that helps you manage,
+validate, and secure your organization's data graph.
+
+In addition to serving as a GraphQL schema registry, Graph Manager ingests operation metadata and execution trace data from your GraphQL server to help you understand
+your schema and query usage.
+
+## Feature summary
+
+**Graph Manager provides the following features to all Apollo users for free:**
+
+* A [GraphQL schema registry](/platform/schema-registry/) that tracks changes
+and enables you to [create variants of your schema](/platform/schema-registry/#managing-environments) for different environments
+(such as staging and production)
+
+* A schema explorer that makes it easy to inspect your schema's queries,
+mutations, and other object definitions
+
+* Team collaboration via [organizations](#managing-organizations)
+
+**Advanced features are available with a subscription to an Apollo Team or Enterprise plan:**
+
+* [Operation safelisting](/platform/operation-registry/)
+* [Schema change validation](/platform/schema-validation/)
+* [Resolver-level query tracing](/platform/performance/)
+* [Third-party integrations](/platform/integrations/)
+* [Management of a federated data graph](/platform/federation/)
+* Longer data retention
+
+[Learn more about pricing and billing](https://www.apollographql.com/plans/)
+
+![The Apollo Graph Manager Architecture](../img/apollo-engine/engine-architecture.png)
+
+## Creating an account
+
+You create your Graph Manager account by authenticating with your GitHub account at [engine.apollographql.com](https://engine.apollographql.com). Your Graph Manager username is the same as your GitHub username.
+
+>Single sign-on (SSO) account management via SAML or OIDC is available for [Enterprise customers](https://www.apollographql.com/plans/).
+
+## Managing organizations
+
+All data in Graph Manager belongs to a particular **organization**. Currently,
+every Graph Manager organization corresponds to either an individual GitHub user or a GitHub organization.
+
+### Single-member organizations
+
+When you create your Graph Manager account via GitHub, an organization is created for you 
+with the same name as your GitHub username. Other users cannot join this organization.
+Feel free to use this organization to try out the features of Graph Manager.
+
+### Collaborating in an organization
+
+Graph Manager automatically creates an organization for every _GitHub_ organization
+ it's granted access to. When you first log in to Graph Manager, it requests permission to view your GitHub organizations, along with the members and teams in those organizations (but **not** the code).
+
+Every member of a GitHub organization is automatically also a member of the corresponding Graph Manager organization (assuming they create a Graph Manager account).
+
+> **WARNING: Currently, all members of a Graph Manager organization have full permissions
+> for the organization, including the ability to delete graphs or transfer them
+> out of the organization.**
+
+#### Adding and removing organization members
+
+To add or remove members from a Graph Manager organization, add or remove those
+same members from the corresponding GitHub organization. Note that only the owner
+of a GitHub organization can remove members.
+
+### Viewing your organizations
+
+The [Graph Manager homepage](https://engine.apollographql.com) lists the organizations you belong to in the left-hand column.
+Click on an organization to view its associated data.
+
+If you’re a member of a GitHub organization and you don't see a corresponding organization in Graph Manager, it's probably because Graph Manager hasn't been granted access
+to that organization.
+
+### Creating and removing organizations
+
+You can view and modify Graph Manager's current access to your GitHub
+organizations on [this GitHub page](https://github.com/settings/connections/applications/4c69c4c9eafb16eab1b5). Note that only owners of a GitHub organization can modify access.
+
+* To create a Graph Manager organization for a particular GitHub organization, simply
+grant Graph Manager access to the GitHub organization.
+
+* To remove a Graph Manager organization, simply revoke Graph Manager's access to
+the corresponding GitHub organization.
+
+>Removing a Graph Manager organization does _not_ delete its associated data. It
+>_does_, however, remove all users from the organization. This prevents anyone from accessing
+>the organization's data and settings until the organization is recreated.
+
+### GitHub permissions and privacy
+
+Graph Manager uses GitHub’s OAuth service to obtain read-only information about organizations and users. Graph Manager does not request access rights to your source code or to any other sensitive data.
+
+## Managing graphs
+
+A **graph** in Graph Manager represents the data graph for a single project or application. Every graph has its own associated GraphQL schema. 
+
+### Creating a graph
+
+To create a graph in the Graph Manager interface, first select the Graph Manager organization
+that the graph will belong to. Then click **New Graph** in the upper right and
+proceed through the creation flow.
+
+Note that every graph in Graph Manager has a globally unique **graph ID**. We recommend that you prefix your graph IDs with the name of your company or organization to avoid naming collisions.
+
+### Viewing graph information
+
+After selecting an organization in Graph Manager, click on a particular graph
+to view its data and settings. All of a Graph Manager organization's members have
+access to the data and settings for every graph that belongs to that organization. 
+
+### Transferring graph ownership
+
+You can transfer a graph to a different Graph Manager organization you belong to
+by visiting the graph's Settings page and changing the **graph owner**.
+
+### Deleting a graph
+
+>**Deleting a graph cannot be undone!**
+
+You can delete a graph from Graph Manager by visiting its Settings page and clicking
+**Delete**.
+
+### Distinguishing between application environments
+
+Every graph in Graph Manager should correspond to a single application. However, a single
+application might run in multiple _environments_ (such as test, staging, and production).
+
+To distinguish between graph activity for different application environments, you can define [**variants**](/platform/schema-registry.html#schema-tags) for a graph. Each variant has its own schema
+that can (but doesn't have to) differ from the default variant.
+
+When your server sends metrics to Graph Manager, it can associate an operation with
+a particular variant. Variants appear as separate items in your organization's graph list, allowing you to view analytics for 
+each application environment in isolation.
+
+## Ingesting and fetching data
+
+Graph Manager ingests and stores performance metrics data sent from your GraphQL server.
+Use one of the following methods to send data to Graph Manager:
+
+* Use [Apollo Server](/apollo-server/) as your application's GraphQL server and [include a Graph Manager API key](/tutorial/production/#get-an-engine-api-key) in your server configuration.
+
+* If you aren't using Apollo Server, you can send trace metrics to the [Graph Manager reporting endpoint](/references/setup-analytics/#engine-reporting-endpoint) (again,
+providing an API key with every request).
+
+### API keys
+
+Any system that communicates with Graph Manager (whether to send metrics or fetch them)
+must use an **API key** to do so. You can add and remove API keys from your graph
+from its Settings page in the Graph Manager UI.
+
+You should use a different API key for each system that communicates
+with Graph Manager. This provides you with more granular control over how Graph
+Manager data is sent and accessed.

--- a/docs/source/references/apollo-engine.md
+++ b/docs/source/references/apollo-engine.md
@@ -1,159 +1,11 @@
 ---
-title: Apollo Graph Manager overview
-description: Account management, graph management, data privacy, and GDPR compliance
+title: Graph Manager data privacy and compliance
+description: Control what Graph Manager ingests and learn about GDPR
 ---
-
-Apollo Graph Manager (formerly Apollo Engine) is a cloud service that helps you manage,
-validate, and secure your organization's data graph. In addition to serving as a GraphQL schema registry, Graph Manager ingests operation metadata and execution trace data from your GraphQL server to provide valuable insights into schema and query usage.
-
-**Graph Manager provides the following features to all Apollo users for free:**
-
-* A [GraphQL schema registry](/docs/platform/schema-registry/) that tracks changes
-and enables you to [create variants of your schema](/docs/platform/schema-registry/#managing-environments) for different environments
-(such as staging and production)
-
-* A schema explorer that makes it easy to inspect your schema's queries,
-mutations, and other object definitions
-
-* Team collaboration via [organizations](#managing-organizations) that mirror
-your GitHub organizations
-
-**Advanced features are available with a subscription to an Apollo Team or Enterprise plan:**
-
-* [Operation safelisting](/docs/platform/operation-registry/)
-* [Schema change validation](/docs/platform/schema-validation/)
-* [Resolver-level query tracing](/docs/platform/performance/)
-* [Third-party integrations](/docs/platform/integrations/)
-* Longer data retention
-
-[Learn more about pricing and billing](https://www.apollographql.com/plans/)
-
-![The Apollo Graph Manager Architecture](../img/apollo-engine/engine-architecture.png)
-
-## Creating an account
-
-You create your Graph Manager account by authenticating with your GitHub account at [engine.apollographql.com](https://engine.apollographql.com). Your Graph Manager username is the same as your GitHub username.
-
->Single sign-on (SSO) account management via SAML or OIDC is available for [Enterprise customers](https://www.apollographql.com/plans/).
-
-## Managing organizations
-
-All data in Graph Manager belongs to a particular **organization**.
-
-### Your personal organization
-
-When you create your
-Graph Manager account via GitHub, a **personal organization** is created for you with the
-same name as your GitHub username. Other users cannot join your personal organization.
-Feel free to use this organization to try out the features of Graph Manager.
-
-### Team organizations
-
-Graph Manager supports **team organizations** that mirror GitHub organizations. When you first log in to Graph Manager, it requests permission to view which GitHub organizations you belong to, along with the members and teams in those organizations (but **not** the code). When Graph Manager first receives permission to view a particular GitHub organization, it creates a Graph Manager organization with the same name.
-
-Every member of a GitHub organization automatically has access to the corresponding Graph Manager organization (assuming they create a Graph Manager account).
-
-> **WARNING: Currently, all members of a Graph Manager organization have full permissions
-> for the organization, including the ability to delete graphs or transfer them
-> out of the organization.**
-
-#### Adding and removing organization members
-
-To add or remove members from a Graph Manager organization, simply add or remove those
-same  members from the corresponding GitHub organization. Note that only the owner
-of a GitHub organization can remove members.
-
-### Viewing your organizations
-
-The [Graph Manager homepage](https://engine.apollographql.com) lists the organizations you belong to in the left-hand column.
-Click on an organization to view its associated data.
-
-If you’re a member of a GitHub organization and you don't see a corresponding organization in Graph Manager, it's probably because Graph Manager doesn't currently have read access for that organization.
-
-### Creating and removing organizations
-
-You can view and modify Graph Manager's current access to your GitHub
-organizations on [this GitHub page](https://github.com/settings/connections/applications/4c69c4c9eafb16eab1b5). Note that only owners of a GitHub organization can modify access.
-
-* To create a Graph Manager organization for a particular GitHub organization, simply
-grant Graph Manager access to the GitHub organization.
-
-* To remove a Graph Manager organization, simply revoke Graph Manager's access to
-the corresponding GitHub organization.
-
-### GitHub permissions and privacy
-
-Graph Manager uses GitHub’s OAuth service to obtain read-only information about organizations and users. Graph Manager does not request access rights to your source code or to any other sensitive data.
-
-## Managing graphs
-
-A **graph** in Graph Manager represents the data graph for a single project or application. Every graph has its own associated GraphQL schema. 
-
-### Creating a graph
-
-To create a graph in the Graph Manager interface, first select the Graph Manager organization
-that the graph will belong to. Then click **New Graph** in the upper right and
-proceed through the creation flow.
-
-Note that every graph in Graph Manager has a globally unique **graph ID**. We recommend that you prefix your graph IDs with the name of your company or organization to avoid naming collisions.
-
-### Viewing graph information
-
-After selecting an organization in Graph Manager, click on a particular graph
-to view its data and settings. All of a Graph Manager organization's members have
-access to the data and settings for every graph that belongs to that organization. 
-
-### Transferring graph ownership
-
-You can transfer a graph to a different Graph Manager organization you belong to
-by visiting the graph's Settings page and changing the **graph owner**.
-
-### Deleting a graph
-
->**Deleting a graph cannot be undone!**
-
-You can delete a graph from Graph Manager by visiting its Settings page and clicking
-**Delete**.
-
-### Distinguishing between application environments
-
-Every graph in Graph Manager should correspond to a single application. However, a single
-application might run in multiple _environments_ (such as test, staging, and production).
-
-To distinguish between graph activity for different application environments, you can define [**variants**](https://www.apollographql.com/docs/platform/schema-registry.html#schema-tags) for a graph. Each variant has its own schema
-that can (but doesn't have to) differ from the default variant.
-
-When your server sends metrics to Graph Manager, it can associate an operation with
-a particular variant. Variants appear as separate items in your organization's graph list, allowing you to view analytics for 
-each application environment in isolation.
-
-## Ingesting and fetching data
-
-Graph Manager ingests and stores performance metrics data sent from your GraphQL server.
-Use one of the following methods to send data to Graph Manager:
-
-* Use [Apollo Server](/docs/apollo-server/) as your application's GraphQL server and [include a Graph Manager API key](/docs/tutorial/production/#get-an-engine-api-key) in your server configuration.
-
-* If you aren't using Apollo Server, you can send trace metrics to the [Graph Manager reporting endpoint](/references/setup-analytics/#engine-reporting-endpoint) (again,
-providing an API key with every request).
-
-### API keys
-
-Any system that communicates with Graph Manager (whether to send metrics or fetch them)
-must use an **API key** to do so. You can add and remove API keys from your graph
-from its Settings page in the Graph Manager UI.
-
-You should use a different API key for each system that communicates
-with Graph Manager. This provides you with more granular control over how Graph
-Manager data is sent and accessed.
-
-## Data transfer and privacy
 
 You can configure Apollo Server to automatically trace the execution of your requests and forward that information to Graph Manager. Graph Manager uses this trace data to reconstruct both operation-level timing data for given query shapes and field-level timing data for your overall schema. This data is available for you to explore and visualize in the Graph Manager interface.
 
-### What does Apollo Server send to Graph Manager?
-
- 
+## What data does Apollo Server send to Graph Manager?
 
 **Apollo Server never forwards the `data` of an operation response to Graph Manager.** It _does_ forward:
 
@@ -167,7 +19,7 @@ Additionally, you can configure Apollo Server to forward some or all of:
 
 * Every operation's [GraphQL variables](#graphql-variables) and [HTTP headers](#http-headers)
 
-#### Operation response fields
+### Operation response fields
 
 Let’s walk through Apollo Server's default behavior for reporting on fields in a typical GraphQL response:
 
@@ -193,38 +45,38 @@ Manager. The responses from your GraphQL service stay internal to your applicati
 By default, if Apollo Server sees a response that includes an `errors` field, it reports the values
 of the error's `message` and `locations` fields (if any) to Graph Manager.
 
-You can use the [`rewriteError` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions) to filter or transform errors before they're stored in
+You can use the [`rewriteError` reporting option](/apollo-server/api/apollo-server/#enginereportingoptions) to filter or transform errors before they're stored in
 Graph Manager. Use this to strip sensitive data from errors or filter "safe" errors from Graph Manager reports.
 
-#### Query operation strings
+### Query operation strings
 
 Apollo Server reports the string representation of each
 query operation to Graph Manager. Consequently, **do not include sensitive data (such
 as passwords or personally identifiable information) in operation strings**. Instead, include this information in [GraphQL variables](#graphql-variables), which you can send selectively.
 
-#### GraphQL variables
+### GraphQL variables
 
-##### Apollo Server 2.7.0 and later
+#### Apollo Server 2.7.0 and later
 
 In Apollo Server 2.7.0 and later, **none** of an
 operation's GraphQL variables is sent to Graph Manager by default.
 
-You can set a value for the [`sendVariableValues` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting
+You can set a value for the [`sendVariableValues` reporting option](/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting
 some or all of your GraphQL variables.
 
-##### Versions prior to 2.7.0
+#### Versions prior to 2.7.0
 
 In versions of Apollo Server 2 _prior_ to 2.7.0, **all** of an operation's GraphQL
 variables are sent to Graph Manager by default.
 
 If you're using an earlier version of Apollo Server, it's recommended that you
 update. If you can't update for whatever reason, you can use the
- [`privateVariables` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions)
+ [`privateVariables` reporting option](/apollo-server/api/apollo-server/#enginereportingoptions)
 to specify the names of variables that should _not_ be sent to Graph Manager. You
 can also set this option to `false` to prevent all variables from being sent.
 This reporting option is deprecated and will not be available in future versions of Apollo Server.
 
-#### HTTP Headers
+### HTTP Headers
 
 Regardless of your server configuration, Graph Manager **never** collects the values
 of the following HTTP headers, even if they're sent:
@@ -238,22 +90,22 @@ You can, however, configure reporting options for all other HTTP headers.
 > **Important:** If you perform authorization in a header other than those listed above
 > (such as `X-My-API-Key`), **do not send that header to Graph Manager**.
 
-##### Apollo Server 2.7.0 and later
+#### Apollo Server 2.7.0 and later
 
 In Apollo Server 2.7.0 and later, **none** of an
 operation's HTTP headers is sent to Graph Manager by default.
 
-You can set a value for the [`sendHeaders` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting
+You can set a value for the [`sendHeaders` reporting option](/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting
 some or all of your HTTP headers.
 
-##### Versions prior to 2.7.0
+#### Versions prior to 2.7.0
 
 In versions of Apollo Server 2 _prior_ to 2.7.0, **all** of an operation's HTTP headers
 (except the confidential headers listed above) are sent to Graph Manager by default.
 
 If you're using an earlier version of Apollo Server, it's recommended that you
 update. If you can't update for
-whatever reason, you can use the [`privateHeaders` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify the names of variables
+whatever reason, you can use the [`privateHeaders` reporting option](/apollo-server/api/apollo-server/#enginereportingoptions) to specify the names of variables
 that should _not_ be sent to Graph Manager. You can also set this
 option to `false` to prevent all headers from being sent.
 This reporting option is deprecated and will not be available in future versions of Apollo Server.

--- a/docs/source/references/apollo-engine.md
+++ b/docs/source/references/apollo-engine.md
@@ -1,46 +1,75 @@
 ---
-title: Apollo Engine guide
-description: Account management, data privacy, GDPR compliance, and other information about Apollo Engine
+title: Apollo Graph Manager overview
+description: Account management, data privacy, GDPR compliance, and more
 ---
 
-[Apollo Engine](https://engine.apollographql.com/) is our cloud service for schema management and performance metrics monitoring. Its foundation is built on a few types of data input from servers: publishing schema introspections, publishing operations from clients, and sending traces of request execution. From those data inputs we can provide rich schema usage insights, schema history management, schema change validation, operation safelisting, query usage insights, and more.
+[Apollo Graph Manager](https://engine.apollographql.com/) is a cloud service for managing
+and monitoring your data graph. Its foundation is built on a few types of data input from servers: publishing schema introspections, publishing operations from clients, and sending traces of request execution. From those data inputs we can provide rich schema usage insights, schema history management, schema change validation, operation safelisting, query usage insights, and more.
 
-Engine's core schema management features are all available in an unlimited capacity for free, and always will be. Engine's advanced features, like operation safelisting, schema change validation, resolver-level query tracing, longer data retention, and third-party integrations are available with subscriptions to the Apollo Team plan.
+Graph Manager's core [schema management features](/docs/platform/schema-registry/) are available in an unlimited capacity for free, and they always will be. Advanced features are available with a subscription to an Apollo Team or Enterprise plan. These features include:
 
-More information on pricing and billing can be found [here](https://www.apollographql.com/plans/).
+* [Operation safelisting](/docs/platform/operation-registry/)
+* [Schema change validation](/docs/platform/schema-validation/)
+* [Resolver-level query tracing](/docs/platform/performance/)
+* [Third-party integrations](/docs/platform/integrations/)
+* Longer data retention
 
-![The Apollo Engine Architecture](../img/apollo-engine/engine-architecture.png)
+[Learn more about pricing and billing](https://www.apollographql.com/plans/)
 
-## Accounts
+![The Apollo Graph Manager Architecture](../img/apollo-engine/engine-architecture.png)
 
-Engine accounts are authenticated using GitHub by default. We also offer single sign-on (SAML or OIDC) to our [Enterprise](https://www.apollographql.com/plans/) customers.
+## Creating an account
 
-### Team collaboration
+You create your Graph Manager account by authenticating with your GitHub account at [engine.apollographql.com](https://engine.apollographql.com). Your Graph Manager username is the same as your GitHub username.
 
-Engine accounts mirror your GitHub organizations. The first time you log in, we create a personal Engine account for you with the same name as your GitHub username.
+>Single sign-on (SSO) account management via SAML or OIDC is available for [Enterprise customers](https://www.apollographql.com/plans/).
 
-The Engine GitHub application asks for permission to read which GitHub organizations you’re in and their members and teams (but not code!). If you grant Engine permission to see an organization, we create an Engine account with the same name as that GitHub organization. All members of that organization on GitHub will be able to see the new account in Engine. This is how you create a shared team account in Engine.
+## Managing organizations
 
-When you sign in to Engine, you will have access to all the teams where you're a member of the organization on GitHub. You can use the organization account picker to switch between accounts. If another member of a GitHub organization you belong to has already signed up the GitHub organization for Engine access, you’ll have access to that existing account.
+All data in Graph Manager belongs to a particular **organization**.
 
-If you’d like to work with additional team members and you are the admin of a GitHub organization, simply add them to your GitHub organization. If you aren’t an admin, have an admin add you to their GitHub organization.
+### The personal organization
+When you create your
+Graph Manager account via GitHub, a **personal organization** is created for you with the
+same name as your GitHub username. Other users cannot join your personal organization.
+Feel free to use this organization to try out the features of Graph Manager.
 
-### Adding an organization
+### Team organizations
 
-If you’re looking for a GitHub organization that you’re a member of and don’t see it in Engine, it’s likely that Engine does not have read access for that organization.
+Graph Manager supports **team organizations** that mirror GitHub organizations. When you first log in to Graph Manager, it requests permission to view which GitHub organizations you belong to, along with the members and teams in those organizations (but **not** the code). When Graph Manager first receives permission to view a particular GitHub organization, it creates a Graph Manager organization with the same name.
 
-If you want to add or remove an organization from Engine, you should manage those settings on GitHub. There, you will be able to Grant or Revoke access to Engine for organizations you can administer. For organizations you do not administer, you can
-"Request" access to Engine and the administrators will receive a request by E-mail.
+Every member of a GitHub organization automatically has access to its corresponding Graph Manager organization (assuming they create a Graph Manager account).
 
-### GitHub permissions
+#### Adding and removing organization members
 
-GitHub’s OAuth service is used for read-only information about organizations and users. Engine does not need access rights to your source code or to any other sensitive data in its login system.
+To add or remove members from a Graph Manager organization, simply remove those
+same  members from the corresponding GitHub organization. Note that only the owner
+of a GitHub organization can remove members.
 
-If your Engine account is owned by a GitHub organization, then Engine will allow all members of that organization to access the account. As you add or remove team members from your Github org, Engine will know about that and accordingly update the authorization for those users.
+### Viewing your organizations
 
-## Graphs
+The [Graph Manager homepage](https://engine.apollographql.com) lists the organizations you belong to in the left-hand column.
+Click on a particular organization to view its associated data.
 
-A _graph_ (formerly called _service_) in Engine represents a _project_ or _application_. When you create a new graph, we provide an API key used to send performance metrics and schema versions to our cloud service. This information is then accessible through the Engine interface.
+If you’re a member of a GitHub organization and you don't see a corresponding organization in Graph Manager, it's probably because Graph Manager doesn't currently have read access for that organization.
+
+### Creating and removing Graph Manager organizations
+
+You can view and modify Graph Manager's current access to your GitHub
+organizations on [this GitHub page](https://github.com/settings/connections/applications/4c69c4c9eafb16eab1b5). Note that only owners of a GitHub organization can modify access.
+
+* To create a Graph Manager organization for a particular GitHub organization, simply
+grant Graph Manager access to the GitHub organization.
+* To remove a Graph Manager organization, simply revoke Graph Manager's access to
+the corresponding GitHub organization.
+
+### GitHub permissions and privacy
+
+Graph Manager uses GitHub’s OAuth service for read-only information about organizations and users. Graph Manager does not request access rights to your source code or to any other sensitive data.
+
+## Managing graphs
+
+A **graph** in Graph Manager represents a project or application. When you create a new graph, Graph Manager generates an API key that your data graph can use to send it performance metrics and schema versions. This information is then accessible through the Graph Manager interface.
 
 ### Creating a graph
 

--- a/docs/source/references/apollo-engine.md
+++ b/docs/source/references/apollo-engine.md
@@ -1,12 +1,12 @@
 ---
 title: Apollo Graph Manager overview
-description: Account management, data privacy, GDPR compliance, and more
+description: Account management, graph management, data privacy, and GDPR compliance
 ---
 
-[Apollo Graph Manager](https://engine.apollographql.com/) is a cloud service for managing
-and monitoring your data graph. Its foundation is built on a few types of data input from servers: publishing schema introspections, publishing operations from clients, and sending traces of request execution. From those data inputs we can provide rich schema usage insights, schema history management, schema change validation, operation safelisting, query usage insights, and more.
+Apollo Graph Manager (formerly Apollo Engine) is a cloud service for managing
+and monitoring your organization's data graph. In addition to serving as a [GraphQL schema registry](/docs/platform/schema-registry/), Graph Manager ingests operation metadata and execution trace data from your GraphQL server to provide valuable insights into schema and query usage.
 
-Graph Manager's core [schema management features](/docs/platform/schema-registry/) are available in an unlimited capacity for free, and they always will be. Advanced features are available with a subscription to an Apollo Team or Enterprise plan. These features include:
+Graph Manager's core schema management features are available in an unlimited capacity for free, and they always will be. Advanced features are available with a subscription to an Apollo Team or Enterprise plan. These features include:
 
 * [Operation safelisting](/docs/platform/operation-registry/)
 * [Schema change validation](/docs/platform/schema-validation/)
@@ -28,7 +28,8 @@ You create your Graph Manager account by authenticating with your GitHub account
 
 All data in Graph Manager belongs to a particular **organization**.
 
-### The personal organization
+### Your personal organization
+
 When you create your
 Graph Manager account via GitHub, a **personal organization** is created for you with the
 same name as your GitHub username. Other users cannot join your personal organization.
@@ -38,141 +39,210 @@ Feel free to use this organization to try out the features of Graph Manager.
 
 Graph Manager supports **team organizations** that mirror GitHub organizations. When you first log in to Graph Manager, it requests permission to view which GitHub organizations you belong to, along with the members and teams in those organizations (but **not** the code). When Graph Manager first receives permission to view a particular GitHub organization, it creates a Graph Manager organization with the same name.
 
-Every member of a GitHub organization automatically has access to its corresponding Graph Manager organization (assuming they create a Graph Manager account).
+Every member of a GitHub organization automatically has access to the corresponding Graph Manager organization (assuming they create a Graph Manager account).
+
+> **WARNING: Currently, all members of a Graph Manager organization have full permissions
+> for the organization, including the ability to delete graphs or transfer them
+> out of the organization.**
 
 #### Adding and removing organization members
 
-To add or remove members from a Graph Manager organization, simply remove those
+To add or remove members from a Graph Manager organization, simply add or remove those
 same  members from the corresponding GitHub organization. Note that only the owner
 of a GitHub organization can remove members.
 
 ### Viewing your organizations
 
 The [Graph Manager homepage](https://engine.apollographql.com) lists the organizations you belong to in the left-hand column.
-Click on a particular organization to view its associated data.
+Click on an organization to view its associated data.
 
 If you’re a member of a GitHub organization and you don't see a corresponding organization in Graph Manager, it's probably because Graph Manager doesn't currently have read access for that organization.
 
-### Creating and removing Graph Manager organizations
+### Creating and removing organizations
 
 You can view and modify Graph Manager's current access to your GitHub
 organizations on [this GitHub page](https://github.com/settings/connections/applications/4c69c4c9eafb16eab1b5). Note that only owners of a GitHub organization can modify access.
 
 * To create a Graph Manager organization for a particular GitHub organization, simply
 grant Graph Manager access to the GitHub organization.
+
 * To remove a Graph Manager organization, simply revoke Graph Manager's access to
 the corresponding GitHub organization.
 
 ### GitHub permissions and privacy
 
-Graph Manager uses GitHub’s OAuth service for read-only information about organizations and users. Graph Manager does not request access rights to your source code or to any other sensitive data.
+Graph Manager uses GitHub’s OAuth service to obtain read-only information about organizations and users. Graph Manager does not request access rights to your source code or to any other sensitive data.
 
 ## Managing graphs
 
-A **graph** in Graph Manager represents a project or application. When you create a new graph, Graph Manager generates an API key that your data graph can use to send it performance metrics and schema versions. This information is then accessible through the Graph Manager interface.
+A **graph** in Graph Manager represents the data graph for a single project or application. Every graph has its own associated GraphQL schema. 
 
 ### Creating a graph
 
-To create a graph, you will need to select an account for that graph to belong to. All members of the account will be able to see the graph's data and settings options. You can transfer graphs between any of your Engine accounts by visiting its Settings page and change the “owner” to whichever account you’d like.
+To create a graph in the Graph Manager interface, first select the Graph Manager organization
+that the graph will belong to. Then click **New Graph** in the upper right and
+proceed through the creation flow.
 
-Graphs in Engine have globally unique IDs. We recommend that you prefix your ID with the name of your company or organization to avoid naming collisions with other graphs in the system.
+Note that every graph in Graph Manager has a globally unique **graph ID**. We recommend that you prefix your graph IDs with the name of your company or organization to avoid naming collisions.
 
-### Managing environments
+### Viewing graph information
 
-Each graph in Engine should represent a single application, and environments within your application should be tracked using [_variants_](https://www.apollographql.com/docs/platform/schema-registry.html#schema-tags). All metrics that your server reports to Engine and all schema versions that you register should be tagged with their environment, and you'll be able to filter and look at the data for individual variants within Engine.
+After selecting an organization in Graph Manager, click on a particular graph
+to view its data and settings. All of a Graph Manager organization's members have
+access to the data and settings for every graph that belongs to that organization. 
 
-#### API keys
+### Transferring graph ownership
 
-API keys can be added and removed from a graph at any time. They are used to both send data to Engine (eg. server reporting configuration) and fetch information from Engine (eg. vs code extension configuration).
+You can transfer a graph to a different Graph Manager organization you belong to
+by visiting the graph's Settings page and changing the **graph owner**.
 
-You can manage your API keys on your graph's settings page. It is recommended that you use one API key per function (eg. one key per data source) to have more granular control over how your Engine data is sent and accessed.
+### Deleting a graph
 
-## Data privacy
+>**Deleting a graph cannot be undone!**
 
-All data that is sent to Engine from your server can be configured and turned off to meet your data privacy needs. This section will walk through what information Engine sees about your GraphQL graph's requests, what Engine’s default behavior to handle request data is, and how you can configure Engine to the level of data privacy your team needs.
+You can delete a graph from Graph Manager by visiting its Settings page and clicking
+**Delete**.
 
-### Architecture
+### Distinguishing between application environments
 
-Engine is primarily a cloud service that ingests and stores performance metrics data from your server. There are two ways to get data into Engine:
+Every graph in Graph Manager should correspond to a single application. However, a single
+application might run in multiple _environments_ (such as test, staging, and production).
 
-1. Use **Apollo Server 2** (Node servers) and configure performance metrics reporting by providing an Engine API key in your server configuration.
-2. Run the **Engine proxy** (deprecated) in front of your server and install an Apollo tracing package in your server.
+To distinguish between graph activity for different application environments, you can define [**variants**](https://www.apollographql.com/docs/platform/schema-registry.html#schema-tags) for a graph. Each variant has its own schema
+that can (but doesn't have to) differ from the default variant.
 
-#### Apollo Server 2
+When your server sends metrics to Graph Manager, it can associate an operation with
+a particular variant. Variants appear as separate items in your organization's graph list, allowing you to view analytics for 
+each application environment in isolation.
 
-If you’ve set up Engine metrics forwarding using Apollo Server 2, Apollo Server will automatically start tracing the execution your requests and forwarding that information to Engine. Engine uses this trace data to reconstruct both operation-level timing data for given query shapes and field-level timing data for your overall schema. This data will become available for you to explore in the Engine interface.
+## Ingesting and fetching data
 
-Apollo Server will never forward the responses of your requests to Engine, but it will forward the shape of your request, the time it took each resolver to execute for that request, and the variables and headers of the request (configurable, see below).
+Graph Manager ingests and stores performance metrics data sent from your GraphQL server.
+Use one of the following methods to send data to Graph Manager:
 
-#### Engine Proxy (deprecated)
+* Use [Apollo Server](/docs/apollo-server/) as your application's GraphQL server and [include a Graph Manager API key](/docs/tutorial/production/#get-an-engine-api-key) in your server configuration.
 
-This configuration option is primarily used to forward metrics to the Engine ingress from non-Node servers. The proxy is installed and run in your own environment on-prem as a separately hosted process that you route your client requests through.
+* If you aren't using Apollo Server, you can send trace metrics to the [Graph Manager reporting endpoint](/references/setup-analytics/#engine-reporting-endpoint) (again,
+providing an API key with every request).
 
-As your clients make requests to your server, the proxy reads response extension data to make caching decisions and aggregates tracing and error information into reports that it sends to the Engine ingress.
+### API keys
 
-While the Engine proxy sees your client request data and service response data, it only collects and forwards data that goes into the reports you see in the Engine dashboards. All information sent by your on-premise proxy to the out-of-band Engine cloud service is configurable, and can be turned off through configuration options. Data is aggregated and sent approximately every 5 seconds.
+Any system that communicates with Graph Manager (whether to send metrics or fetch them)
+must use an **API key** to do so. You can add and remove API keys from your graph
+from its Settings page in the Graph Manager UI.
 
-### Data collection
+You should use a different API key for each system that communicates
+with Graph Manager. This provides you with more granular control over how Graph
+Manager data is sent and accessed.
 
-This section describes which parts of your GraphQL HTTP requests are seen and collected by Engine.
+## Data transfer and privacy
 
-#### Query operation string
+You can configure Apollo Server to automatically trace the execution of your requests and forward that information to Graph Manager. Graph Manager uses this trace data to reconstruct both operation-level timing data for given query shapes and field-level timing data for your overall schema. This data is available for you to explore and visualize in the Graph Manager interface.
 
-Both Apollo Server 2 and the Engine proxy report the full operation string of your request to the Engine cloud service. Because of this, you should be careful to put any sensitive data like passwords and personal data in the GraphQL variables object rather than in the operation string itself.
+### What does Apollo Server send to Graph Manager?
 
-#### Variables
+ 
 
-Both Apollo Server 2 and the Engine proxy will report the query variables for each request to the Engine cloud service by default. This can be disabled in the following ways:
+**Apollo Server never forwards the `data` of an operation response to Graph Manager.** It _does_ forward:
 
-- **Apollo Server 2** – use the privateVariables option in your Apollo Server configuration for Engine.
-- **Engine proxy** – use the privateVariables option in your proxy configuration, or prevent all variables from being reported with noTraceVariables option.
+* Several fields _besides_ `data` from every operation response
 
-#### Authorization & Cookie HTTP Headers
+* The [query operation string](#query-operation-strings) for every executed operation
 
-Engine will **never** collect your application's `Authorization`, `Cookie`, or `Set-Cookie` headers and ignores these if received. Engine will collect all other headers from your request to show in the trace inspector unless turned off with these configurations:
+* The time it takes each resolver to execute for every operation
 
-- **Apollo Server 2** – use the [`privateHeaders` option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#EngineReportingOptions) in your Apollo Server configuration for Engine.
-- **Engine Proxy** – use the [`privateHeaders` option](/references/proxy-config/#reporting) in your proxy configuration.
+Additionally, you can configure Apollo Server to forward some or all of:
 
-If you perform authorization in another header (like `X-My-API-Key`), be sure to add this to `privateHeaders` configuration. Note that unlike headers in general, this configuration option **is** case-sensitive.
+* Every operation's [GraphQL variables](#graphql-variables) and [HTTP headers](#http-headers)
 
-### Response
+#### Operation response fields
 
-Let’s walk through Engine’s default behavior for reporting on fields in a typical GraphQL response:
+Let’s walk through Apollo Server's default behavior for reporting on fields in a typical GraphQL response:
 
 ```json
 // GraphQL Response
 {
-  "data": { ... },          // Never sent to the Engine cloud service
-  "errors": [ ... ],        // Sent to Engine, used to report on errors for operations and fields.
+  "data": { ... },          // NEVER sent to Graph Manager.
+  "errors": [ ... ],        // Sent to Graph Manager, used to report on errors for operations and fields.
   "extensions": {
-    "tracing": { ... },     // Sent to Engine, used to report on performance data for operations and fields.
-    "cacheControl": { ... } // Sent to Engine, used to determine cache policies and forward CDN cache headers.
+    "tracing": { ... },     // Sent to Graph Manager, used to report on performance data for operations and fields.
+    "cacheControl": { ... } // Sent to Graph Manager, used to determine cache policies and forward CDN cache headers.
   }
 }
 ```
 
 #### `response.data`
 
-Neither Apollo Server 2 nor the Engine proxy will ever send the contents of this to the Engine cloud service. The responses from your GraphQL service stay on-prem.
-
-If you've configured whole query caching through the Engine proxy and Engine determines that a response it sees is cacheable, then the response will be stored in your [cache](https://www.apollographql.com/docs/apollo-server/features/caching/#saving-full-responses-to-a-cache) (either in-memory in your proxy or as an external memcached you configure).
+As mentioned, Apollo Server **never** sends the contents of this field to Graph
+Manager. The responses from your GraphQL service stay on-prem.
 
 #### `response.errors`
 
-If either Apollo Server 2 or the Engine proxy sees a response with an `"errors"` field, they will read the `message` and `locations` fields if they exist and report them to the Engine cloud service.
+By default, if Apollo Server sees a response that includes an `errors` field, it reports the values
+of the error's `message` and `locations` fields (if any) to Graph Manager.
 
-You can disable reporting errors to the out-of-band Engine cloud service like so:
+You can use the [`rewriteError` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions) to filter or transform errors before they're stored in
+Graph Manager. Use this to strip sensitive data from errors or filter "safe" errors from Graph Manager reports.
 
-- **Apollo Server 2** &mdash; enable the [`maskErrorDetails` option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#EngineReportingOptions) to remove the messages and other details from error traces sent to Apollo's cloud service.
-- **Apollo Server 2** &mdash; specify a [`rewriteError` function](https://www.apollographql.com/docs/apollo-server/features/errors/#for-apollo-engine-reporting) that filters or transforms your errors before they are sent to Apollo's cloud service. This can be used to strip sensitive data from errors or filter "safe" errors from Engine's reporting.
-- **Engine proxy** &mdash; use the [`noTraceErrors` option](/references/proxy-config/#reporting) to disable sending error traces to the Engine cloud service.
+#### Query operation strings
 
-#### Disable Reporting (Engine proxy)
+Apollo Server reports the string representation of each
+query operation to Graph Manager. Consequently, **do not include sensitive data (such
+as passwords or personally identifiable information) in operation strings**. Instead, include this information in [GraphQL variables](#graphql-variables), which you can send selectively.
 
-We've added the option to disable reporting of proxy stats and response traces to the Engine cloud service so that integration tests can run without polluting production data.
+#### GraphQL variables
 
-To disable all reporting, use the [`disabled` option](/references/proxy-config/#reporting) for the Engine proxy.
+##### Apollo Server 2.7.0 and later
+
+In Apollo Server 2.7.0 and later, **none** of an
+operation's GraphQL variables is sent to Graph Manager by default.
+
+You can set a value for the [`sendVariableValues` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting
+some or all of your GraphQL variables.
+
+##### Versions prior to 2.7.0
+
+In versions of Apollo Server 2 _prior_ to 2.7.0, **all** of an operation's GraphQL
+variables are sent to Graph Manager by default.
+
+If you're using an earlier version of Apollo Server, it's recommended that you
+update. If you can't update for
+whatever reason, you can use the [`privateVariables` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify the names of variables
+that should _not_ be sent to Graph Manager. This reporting option is deprecated
+and will not be available in future versions of Apollo Server.
+
+#### HTTP Headers
+
+Regardless of your server configuration, Graph Manager **never** collects the values
+of the following HTTP headers, even if they're sent:
+
+* `Authorization`
+* `Cookie`
+* `Set-Cookie`
+
+You can, however, configure reporting options for all other HTTP headers.
+
+> If you perform authorization in another header (such as `X-My-API-Key`), **do not send
+>that header to Graph Manager**.
+
+##### Apollo Server 2.7.0 and later
+
+In Apollo Server 2.7.0 and later, **none** of an
+operation's HTTP headers is sent to Graph Manager by default.
+
+You can set a value for the [`sendHeaders` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting
+some or all of your HTTP headers.
+
+##### Versions prior to 2.7.0
+
+In versions of Apollo Server 2 _prior_ to 2.7.0, **all** of an operation's HTTP headers
+(except the confidential headers listed above) are sent to Graph Manager by default.
+
+If you're using an earlier version of Apollo Server, it's recommended that you
+update. If you can't update for
+whatever reason, you can use the [`privateHeaders` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify the names of variables
+that should _not_ be sent to Graph Manager. This reporting option is deprecated
+and will not be available in future versions of Apollo Server.
 
 <!--
 ######################################################################

--- a/docs/source/references/apollo-engine.md
+++ b/docs/source/references/apollo-engine.md
@@ -3,10 +3,22 @@ title: Apollo Graph Manager overview
 description: Account management, graph management, data privacy, and GDPR compliance
 ---
 
-Apollo Graph Manager (formerly Apollo Engine) is a cloud service for managing
-and monitoring your organization's data graph. In addition to serving as a [GraphQL schema registry](/docs/platform/schema-registry/), Graph Manager ingests operation metadata and execution trace data from your GraphQL server to provide valuable insights into schema and query usage.
+Apollo Graph Manager (formerly Apollo Engine) is a cloud service that helps you manage,
+validate, and secure your organization's data graph. In addition to serving as a GraphQL schema registry, Graph Manager ingests operation metadata and execution trace data from your GraphQL server to provide valuable insights into schema and query usage.
 
-Graph Manager's core schema management features are available in an unlimited capacity for free, and they always will be. Advanced features are available with a subscription to an Apollo Team or Enterprise plan. These features include:
+**Graph Manager provides the following features to all Apollo users for free:**
+
+* A [GraphQL schema registry](/docs/platform/schema-registry/) that tracks changes
+and enables you to [create variants of your schema](/docs/platform/schema-registry/#managing-environments) for different environments
+(such as staging and production)
+
+* A schema explorer that makes it easy to inspect your schema's queries,
+mutations, and other object definitions
+
+* Team collaboration via [organizations](#managing-organizations) that mirror
+your GitHub organizations
+
+**Advanced features are available with a subscription to an Apollo Team or Enterprise plan:**
 
 * [Operation safelisting](/docs/platform/operation-registry/)
 * [Schema change validation](/docs/platform/schema-validation/)
@@ -174,7 +186,7 @@ Let’s walk through Apollo Server's default behavior for reporting on fields in
 #### `response.data`
 
 As mentioned, Apollo Server **never** sends the contents of this field to Graph
-Manager. The responses from your GraphQL service stay on-prem.
+Manager. The responses from your GraphQL service stay internal to your application.
 
 #### `response.errors`
 
@@ -206,10 +218,11 @@ In versions of Apollo Server 2 _prior_ to 2.7.0, **all** of an operation's Graph
 variables are sent to Graph Manager by default.
 
 If you're using an earlier version of Apollo Server, it's recommended that you
-update. If you can't update for
-whatever reason, you can use the [`privateVariables` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify the names of variables
-that should _not_ be sent to Graph Manager. This reporting option is deprecated
-and will not be available in future versions of Apollo Server.
+update. If you can't update for whatever reason, you can use the
+ [`privateVariables` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions)
+to specify the names of variables that should _not_ be sent to Graph Manager. You
+can also set this option to `false` to prevent all variables from being sent.
+This reporting option is deprecated and will not be available in future versions of Apollo Server.
 
 #### HTTP Headers
 
@@ -222,8 +235,8 @@ of the following HTTP headers, even if they're sent:
 
 You can, however, configure reporting options for all other HTTP headers.
 
-> If you perform authorization in another header (such as `X-My-API-Key`), **do not send
->that header to Graph Manager**.
+> **Important:** If you perform authorization in a header other than those listed above
+> (such as `X-My-API-Key`), **do not send that header to Graph Manager**.
 
 ##### Apollo Server 2.7.0 and later
 
@@ -241,8 +254,9 @@ In versions of Apollo Server 2 _prior_ to 2.7.0, **all** of an operation's HTTP 
 If you're using an earlier version of Apollo Server, it's recommended that you
 update. If you can't update for
 whatever reason, you can use the [`privateHeaders` reporting option](/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify the names of variables
-that should _not_ be sent to Graph Manager. This reporting option is deprecated
-and will not be available in future versions of Apollo Server.
+that should _not_ be sent to Graph Manager. You can also set this
+option to `false` to prevent all headers from being sent.
+This reporting option is deprecated and will not be available in future versions of Apollo Server.
 
 <!--
 ######################################################################

--- a/docs/source/references/engine-proxy.md
+++ b/docs/source/references/engine-proxy.md
@@ -3,7 +3,8 @@ title: Apollo Engine proxy (deprecated)
 description: Configuring and running the Engine proxy
 ---
 
-> DEPRECATED: The engine proxy is not maintained, and to integrate with the Apollo platform's metrics, we recommend using Apollo Server's native reporting functionality. To integrate a non-Node server, take a look at our guide [here](/references/setup-analytics/#other-servers).
+> **Engine proxy is deprecated.** Current users of Engine proxy should migrate their
+> system to use either Apollo Server or the [Graph Manager reporting endpoint](/references/setup-analytics/#engine-reporting-endpoint).
 
 ## Background
 

--- a/docs/source/references/graph-manager-data-privacy.md
+++ b/docs/source/references/graph-manager-data-privacy.md
@@ -45,7 +45,7 @@ Manager. The responses from your GraphQL service stay internal to your applicati
 By default, if Apollo Server sees a response that includes an `errors` field, it reports the values
 of the error's `message` and `locations` fields (if any) to Graph Manager.
 
-You can use the [`rewriteError` reporting option](/apollo-server/api/apollo-server/#enginereportingoptions) to filter or transform errors before they're stored in
+You can use the [`rewriteError` reporting option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions) to filter or transform errors before they're stored in
 Graph Manager. Use this to strip sensitive data from errors or filter "safe" errors from Graph Manager reports.
 
 ### Query operation strings
@@ -61,7 +61,7 @@ as passwords or personally identifiable information) in operation strings**. Ins
 In Apollo Server 2.7.0 and later, **none** of an
 operation's GraphQL variables is sent to Graph Manager by default.
 
-You can set a value for the [`sendVariableValues` reporting option](/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting
+You can set a value for the [`sendVariableValues` reporting option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting
 some or all of your GraphQL variables.
 
 #### Versions prior to 2.7.0
@@ -71,7 +71,7 @@ variables are sent to Graph Manager by default.
 
 If you're using an earlier version of Apollo Server, it's recommended that you
 update. If you can't update for whatever reason, you can use the
- [`privateVariables` reporting option](/apollo-server/api/apollo-server/#enginereportingoptions)
+ [`privateVariables` reporting option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions)
 to specify the names of variables that should _not_ be sent to Graph Manager. You
 can also set this option to `false` to prevent all variables from being sent.
 This reporting option is deprecated and will not be available in future versions of Apollo Server.
@@ -95,7 +95,7 @@ You can, however, configure reporting options for all other HTTP headers.
 In Apollo Server 2.7.0 and later, **none** of an
 operation's HTTP headers is sent to Graph Manager by default.
 
-You can set a value for the [`sendHeaders` reporting option](/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting
+You can set a value for the [`sendHeaders` reporting option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting
 some or all of your HTTP headers.
 
 #### Versions prior to 2.7.0
@@ -105,7 +105,7 @@ In versions of Apollo Server 2 _prior_ to 2.7.0, **all** of an operation's HTTP 
 
 If you're using an earlier version of Apollo Server, it's recommended that you
 update. If you can't update for
-whatever reason, you can use the [`privateHeaders` reporting option](/apollo-server/api/apollo-server/#enginereportingoptions) to specify the names of variables
+whatever reason, you can use the [`privateHeaders` reporting option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify the names of variables
 that should _not_ be sent to Graph Manager. You can also set this
 option to `false` to prevent all headers from being sent.
 This reporting option is deprecated and will not be available in future versions of Apollo Server.

--- a/docs/source/references/graph-manager-data-privacy.md
+++ b/docs/source/references/graph-manager-data-privacy.md
@@ -1,6 +1,6 @@
 ---
 title: Graph Manager data privacy and compliance
-description: Control what Graph Manager ingests and learn about GDPR
+description: Understand what Graph Manager ingests and learn about GDPR
 ---
 
 You can configure Apollo Server to automatically trace the execution of your requests and forward that information to Graph Manager. Graph Manager uses this trace data to reconstruct both operation-level timing data for given query shapes and field-level timing data for your overall schema. This data is available for you to explore and visualize in the Graph Manager interface.

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,5 +1,8 @@
 / /docs/
 
+# Split "Apollo Engine guide" into two articles
+/docs/references/apollo-engine/ /docs/platform/graph-manager-overview/
+
 # Redirect Removed Guides to Platform Features
 /docs/guides/security.html /docs/platform/operation-registry.html
 /docs/guides/monitoring.html /docs/platform/integrations.html


### PR DESCRIPTION
This change seeks to better convey the components and purpose of the Apollo platform on the documentation homepage.

In service of that change, this PR also adds an overview for Graph Manager, which currently doesn't have an obvious first-place-to-go in the docs. The overview's content is pulled partly from the "Engine guide", which is being renamed to "Graph Manager Data Privacy and Compliance" to better reflect its focused scope.