### PR TITLE
docs: Rename schema to typeDefs

### DIFF
--- a/docs/source/tutorial/local-state.md
+++ b/docs/source/tutorial/local-state.md
@@ -174,7 +174,7 @@ _src/resolvers.js_
 ```js
 import gql from 'graphql-tag';
 
-export const schema = gql`
+export const typeDefs = gql`
   extend type Launch {
     isInCart: Boolean!
   }


### PR DESCRIPTION
Keep the naming the consistent with the previous instruction.

When the type extension is first introduced at [`Write a local schema`,](https://github.com/apollographql/apollo/blob/master/docs/source/tutorial/local-state.md#write-a-local-schema)
its defined within the `typeDefs` constant. It's also within typeDefs in 
the final/client folder's resolvers.js. 
- Defining it under `scheme` can be confusing for beginners who
  might set another constant.