### PR TITLE
[tutorial 3] resolvers.md: add actual field instead of comment

### DIFF
--- a/docs/source/tutorial/resolvers.md
+++ b/docs/source/tutorial/resolvers.md
@@ -256,7 +256,7 @@ Mission: {
 _src/schema.js_
 ```js
   type Mission {
-    # ... with rest of schema
+    name: String
     missionPatch(mission: String, size: PatchSize): String
   }
 ```


### PR DESCRIPTION
# Overview

I changed comment to actual type definition in the [3. Write your graph's resolvers](https://www.apollographql.com/docs/tutorial/resolvers/#write-resolvers-on-types) `src/resolvers.js` code highlight.

Full definition appears at [1. Build a schema: Object & scalar types section](https://www.apollographql.com/docs/tutorial/schema/#object--scalar-types), and `type Mission` has 2 field.

- Full definition
<img width="785" alt="actual" src="https://user-images.githubusercontent.com/5501268/64615980-85c28e80-d416-11e9-8b35-2c5635c8ac23.png">

Other place, `type Mission` appears second time in [3. Write your graph's resolvers](https://www.apollographql.com/docs/tutorial/resolvers/#write-resolvers-on-types) `src/resolvers.js` code highlight.

- My changed point
<img width="769" alt="mychanged" src="https://user-images.githubusercontent.com/5501268/64616043-a8ed3e00-d416-11e9-9942-de076d8638f7.png">

I copied second one and overwrite full definition, and then I've just noticed lacking `name: String` field by error message when I proceeding [Chapter 5](https://www.apollographql.com/docs/tutorial/client/#make-your-first-query)😅

I thought abbreviation comment may not need for only 1 field.


Thank you for making so practical tutorials! 😄