### PR TITLE
[tutorial 8][local-state.md] add lacking import statement

### DIFF
--- a/docs/source/tutorial/local-state.md
+++ b/docs/source/tutorial/local-state.md
@@ -173,6 +173,7 @@ _src/resolvers.js_
 
 ```js
 import gql from 'graphql-tag';
+import { GET_CART_ITEMS } from './pages/cart';
 
 export const schema = gql`
   extend type Launch {


### PR DESCRIPTION
# Overview

In `src/resolvers.js` file, lacking  `GET_CART_ITEMS` query import.

Thank you for reading 😀