### PR TITLE
Add reference to Apollo Server proxy configuration documentation.

### DIFF
--- a/graph-manager-docs/source/federation.mdx
+++ b/graph-manager-docs/source/federation.mdx
@@ -117,7 +117,7 @@ server.listen().then(({ url }) => {
 });
 ```
 
-> The managed configuration will default to using the `'current'` variant.
+> The managed configuration will default to using the `'current'` variant.  When running Apollo Gateway in an environment where outbound traffic to the internet is restricted, consult the [directions for configuring a proxy](https://www.apollographql.com/docs/apollo-server/proxy-configuration/) within Apollo Server.
 
 ### Managed configuration
 


### PR DESCRIPTION
In some environments where outbound traffic is restricted, it may be necessary to configure the Apollo Gateway and Apollo Server to route their outgoing traffic through a proxy (corporate, or otherwise).  These instructions now exist within the Apollo Server documentation (https://www.apollographql.com/docs/apollo-server/proxy-configuration/) an this adds a reference accordingly.

Follows-up: https://github.com/apollographql/apollo-server/pull/3332 (on the Apollo Server repository)