### PR TITLE
Inconsistent use of semi-colons

### DIFF
--- a/docs/source/tutorial/client.md
+++ b/docs/source/tutorial/client.md
@@ -72,12 +72,12 @@ import { HttpLink } from 'apollo-link-http';
 const cache = new InMemoryCache();
 const link = new HttpLink({
   uri: 'http://localhost:4000/'
-})
+});
 
 const client = new ApolloClient({
   cache,
   link
-})
+});
 ```
 
 In just a few lines of code, our client is ready to fetch data! Let's try making a query in the next section.


### PR DESCRIPTION
Sample code does not have trailing semi-colons which is inconsistent with other examples.