### PR TITLE
WIP: Add a Graph Manager link to a page

### DIFF
--- a/graph-manager-docs/source/index.md
+++ b/graph-manager-docs/source/index.md
@@ -1,6 +1,7 @@
 ---
 title: Overview
 description: Learn about Graph Manager features and create your account
+graphManagerUrl: https://engine.apollographql.com
 ---
 
 Apollo Graph Manager (formerly Apollo Engine) is a cloud service that helps you manage,


### PR DESCRIPTION
This branch should serve as a demo of how to add a link to GM to the right sidebar of a page in the docs.

Theme PR: https://github.com/apollographql/gatsby-theme-apollo/pull/66