### PR TITLE
fix: no need for destructuring the argument

### DIFF
--- a/docs/source/tutorial/data-source.md
+++ b/docs/source/tutorial/data-source.md
@@ -102,7 +102,7 @@ Next, let's take care of fetching a specific launch by its ID. Let's add two met
 _src/datasources/launch.js_
 
 ```js
-async getLaunchById({ launchId }) {
+async getLaunchById(launchId) {
   const response = await this.get('launches', { flight_number: launchId });
   return this.launchReducer(response[0]);
 }


### PR DESCRIPTION
The flight ID is already passed in as an atomic value (see resolvers).