### PR TITLE
Please document local resolvers using the { client } method

### DIFF
--- a/docs/source/tutorial/local-state.md
+++ b/docs/source/tutorial/local-state.md
@@ -321,7 +321,7 @@ _src/resolvers.js_
 ```js
 export const resolvers = {
   Mutation: {
-    addOrRemoveFromCart: (_, { id }, { cache }) => {
+    addOrRemoveFromCart: (_, { id }, { client }) => {
       const { cartItems } = cache.readQuery({ query: GET_CART_ITEMS });
       const data = {
         cartItems: cartItems.includes(id)


### PR DESCRIPTION
rather than the { cache } method

To my understanding - method calls like cache.writeData don't broadcast changes to any subscribed components ... why would this be the default used in documentation??  It's ridiculously confusing and very difficult to figure out that what you _actually want_ in 99% of cases is to use client.writeData(...)