### PR TITLE
Missing async on getLaunchesByIds

### DIFF
--- a/docs/source/tutorial/data-source.md
+++ b/docs/source/tutorial/data-source.md
@@ -107,7 +107,7 @@ async getLaunchById({ launchId }) {
   return this.launchReducer(response[0]);
 }
 
-getLaunchesByIds({ launchIds }) {
+async getLaunchesByIds({ launchIds }) {
   return Promise.all(
     launchIds.map(launchId => this.getLaunchById({ launchId })),
   );


### PR DESCRIPTION
Fixed a typo. `getLaunchesByIds` example was show missing an `async` statement in front. The same file in the `final` folder has the `async` descriptor and, well, it's required. :-)