### PR TITLE
Operation name `login` should be `Login` in PascalCase

### DIFF
--- a/docs/source/tutorial/mutations.md
+++ b/docs/source/tutorial/mutations.md
@@ -27,7 +27,7 @@ import gql from 'graphql-tag';
 import { LoginForm, Loading } from '../components';
 
 const LOGIN_USER = gql`
-  mutation login($email: String!) {
+  mutation Login($email: String!) {
     login(email: $email)
   }
 `;


### PR DESCRIPTION
Fix graphQL operation name `login`, which should be `Login` with PascalCase