### PR TITLE
Client Tutorial: consistently use single quotes

### DIFF
--- a/docs/source/tutorial/client.md
+++ b/docs/source/tutorial/client.md
@@ -91,7 +91,7 @@ With a `client.query()` call, we can query our graph's API. Add the following li
 _src/index.js_
 
 ```js
-import gql from "graphql-tag"; // highlight-line
+import gql from 'graphql-tag'; // highlight-line
 ```
 
 And add this code to the bottom of `index.js`:


### PR DESCRIPTION
Change double to single quotes, as being used for all the other imports in the sample code.