### PR TITLE
Tutorial: always use the most recent token value for authorization

### DIFF
--- a/docs/source/tutorial/local-state.mdx
+++ b/docs/source/tutorial/local-state.mdx
@@ -85,7 +85,9 @@ const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
   link: new HttpLink({
     uri: 'http://localhost:4000/graphql',
     headers: {
-      authorization: localStorage.getItem('token'),
+      get authorization() {
+        return localStorage.getItem('token')
+      },
     },
   }),
   typeDefs,

--- a/docs/source/tutorial/mutations.mdx
+++ b/docs/source/tutorial/mutations.mdx
@@ -105,8 +105,10 @@ const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
   link: new HttpLink({
     uri: 'http://localhost:4000/graphql',
     headers: {
-      authorization: localStorage.getItem('token'),
-    }, 
+      get authorization() {
+        return localStorage.getItem('token')
+      },
+    },
   }),
 });
 
@@ -123,7 +125,11 @@ cache.writeData({
 const client = new ApolloClient({
   cache,
   link: new HttpLink({
-    headers: { authorization: localStorage.getItem('token') },
+    headers: {
+      get authorization() {
+        return localStorage.getItem('token')
+      },
+    },
     uri: "http://localhost:4000/graphql",
   }),
 });


### PR DESCRIPTION
Right now login doesn't work without page reload, because token value is only read once at app start