### PR TITLE
Replace Slack with Spectrum, UNIX-ify CONTRIBUTING

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -12,7 +12,7 @@ The project gains strength from a diversity of backgrounds and perspectives in o
 
 This isn’t an exhaustive list of things that you can’t do. Rather, it’s a guide for participation in the community that outlines how each of us can work to keep Apollo a positive, successful, and growing project.
 
-This code of conduct applies to all spaces managed by the Apollo project or company. This includes Slack, GitHub issues, the GraphQL Summit and GraphQL SF events, and any other forums created by the Apollo team which the community uses for communication. Breaches of this code outside these spaces may affect a person's ability to participate within them. We expect it to be honored by everyone who represents or participates in the project, whether officially or informally.
+This code of conduct applies to all spaces managed by the Apollo project or company. This includes Spectrum, Slack, GitHub issues, the GraphQL Summit and GraphQL SF events, and any other forums created by the Apollo team which the community uses for communication. Breaches of this code outside these spaces may affect a person's ability to participate within them. We expect it to be honored by everyone who represents or participates in the project, whether officially or informally.
 
 If you believe someone is violating the code of conduct, please report it by emailing [community@apollodata.com](mailto:community@apollostack.com).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Excited about Apollo and want to make it better? We’re excited too!
 
 Apollo is a community of developers just like you, striving to create the best tools and libraries around GraphQL. We welcome anyone who wants to contribute or provide constructive feedback, no matter the age or level of experience. If you want to help but don't know where to start, let us know, and we'll find something for you.
 
-First and foremost, you should take a moment to review the [Apollo Code of Conduct](https://github.com/apollographql/apollo/blob/master/CODE-OF-CONDUCT.md) which all maintainers and contributors to the project agree to uphold. Next, you should sign up for the [Apollo Slack](https://www.apollographql.com/#slack). The **#contributing** channel there will be a great resource to chat with project maintainers and other contributors if you need help navigating our workflow. 
+First and foremost, you should take a moment to review the [Apollo Code of Conduct](https://github.com/apollographql/apollo/blob/master/CODE-OF-CONDUCT.md) which all maintainers and contributors to the project agree to uphold. Next, you should sign up for the [Apollo Spectrum community](https://spectrum.chat/apollo). The **#contributing** channel there will be a great resource to chat with project maintainers and other contributors if you need help navigating our workflow.
 
 Here are some ways to contribute to the project, from easiest to most difficult:
 
@@ -35,7 +35,7 @@ Improving the documentation, examples, and other open source content can be the 
 
 ### Responding to issues
 
-In addition to reporting issues, a great way to contribute to Apollo is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. And don't forget to say "Hi" on Apollo Slack!
+In addition to reporting issues, a great way to contribute to Apollo is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. And don't forget to say hi on Spectrum!
 
 ### Small bug fixes
 


### PR DESCRIPTION
CONTRIBUTING.md seemed to use non-Unix newline conventions, so this resolves that in addition to pointing folks to Spectrum instead of Slack