### PR TITLE
Remove vestigial(?) reference to previous section

### DIFF
--- a/docs/source/tutorial/resolvers.md
+++ b/docs/source/tutorial/resolvers.md
@@ -174,7 +174,7 @@ type LaunchConnection { # add this below the Query type as an additional type.
 
 You'll also notice we've added comments (also called docstrings) to our schema, indicated by `"""`. Now, the `launches` query takes in two parameters, `pageSize` and `after`, and returns a `LaunchConnection`. The `LaunchConnection` type returns a result that shows the list of launches, in addition to a `cursor` field that keeps track of where we are in the list and a `hasMore` field to indicate if there's more data to be fetched.
 
-Open up the `src/utils.js` file in the repo you cloned in the previous section and check out the `paginateResults` function. The `paginateResults` function in the file is a helper function for paginating data from the server. Now, let's update the necessary resolver functions to accommodate pagination.
+Open up the `src/utils.js` file and check out the `paginateResults` function. The `paginateResults` function in the file is a helper function for paginating data from the server. Now, let's update the necessary resolver functions to accommodate pagination.
 
 Let's import `paginateResults` and replace the `launches` resolver function in the `src/resolvers.js` file with the code below:
 


### PR DESCRIPTION
I'm not sure if this is trying to say that we cloned the entire repo in the previous section, or just that we copied code into the `src/utils.js` file in the previous section, but either way that isn't true. We cloned the repo several sections ago, and we didn't have to explicitly copy the `utils.js` file ever. Seems more concise to just remove it.