### PR TITLE
Remove reference to previous deployment step

### DIFF
--- a/docs/source/tutorial/client.mdx
+++ b/docs/source/tutorial/client.mdx
@@ -63,9 +63,7 @@ Great, we're all set up! Let's dive into building our first client.
 
 Now that we have installed the necessary packages, let's create an `ApolloClient` instance.
 
-Navigate to `src/index.tsx` so we can create our client. The `uri` that we pass in is the graph endpoint from the service you deployed in step 4.
-
-If you didn't complete the server portion, you can use the `uri` from the code below. Otherwise, use your own deployment's URL, which may be different than the one below. Navigate to `src/index.tsx` and copy the code below:
+Navigate to `src/index.tsx` and copy the code below:
 
 <MultiCodeBlock>
 


### PR DESCRIPTION
During the tutorial step: "5. Connect your API to a client", I spent a good while trying to figure out what I'd missed from the previous step: "4. Run your graph in production", as I didn't have a URL for my deployment to pass into the client.

It wasn't until I looked into the file history that I realised a couple of PRs (https://github.com/apollographql/apollo/pull/444 and https://github.com/apollographql/apollo/pull/541) had removed the step of actually deploying the GraphQL service, due to some issues running `npx now`.

Ideally these issues would be resolved and the deployment step could be added back in, as it would be nice to run the client against a real remote deployment, but until then, this change should prevent people stopping in their tracks during the tutorial and wondering what they've missed.