### PR TITLE
A incorrect file type fixed(small issue)

### DIFF
--- a/docs/source/tutorial/queries.mdx
+++ b/docs/source/tutorial/queries.mdx
@@ -341,7 +341,7 @@ Let's use our fragment in our launch detail query too. Be sure to import the fra
 
 <MultiCodeBlock>
 
-```js{1,10,14}:title=src/pages/launch.tsx
+```tsx:title=src/pages/launch.tsx
 import { LAUNCH_TILE_DATA } from './launches';
 
 export const GET_LAUNCH_DETAILS = gql`


### PR DESCRIPTION
## Summary
In a tutorial of `6. Fetch data with queries`, a file type is written `jsx` instead of `tsx`.  

## issue
The file name is `src/pages/launch.tsx`, but that file type is `JavaScript`.
I think it should be fixed.


## DIFF
#### Incorrect
[![Screenshot from Gyazo](https://gyazo.com/9edd8937f8d5f00f0edbbc47481bb3eb/raw)](https://gyazo.com/9edd8937f8d5f00f0edbbc47481bb3eb)

#### Correct
[![Screenshot from Gyazo](https://gyazo.com/2ff87d9d1ff8be46993f25e14a60a40d/raw)](https://gyazo.com/2ff87d9d1ff8be46993f25e14a60a40d)

Thank you.