### PR TITLE
Changed "Apollo data source" to "Apollo data source API"

### DIFF
--- a/docs/source/tutorial/data-source.md
+++ b/docs/source/tutorial/data-source.md
@@ -7,7 +7,7 @@ Time to accomplish: _10 Minutes_
 
 Now that we've constructed our schema, we need to hook up our data sources to our GraphQL API. GraphQL APIs are extremely flexible because you can layer them on top of any service, including any business logic, REST APIs, databases, or gRPC services.
 
-Apollo makes connecting these services to your graph simple with our data source API. An **Apollo data source** is a class that encapsulates all of the data fetching logic, as well as caching and deduplication, for a particular service. By using Apollo data sources to hook up your services to your graph API, you're also following best practices for organizing your code.
+Apollo makes connecting these services to your graph simple with our data source API. An **Apollo data source API** is a class that encapsulates all of the data fetching logic, as well as caching and deduplication, for a particular service. By using Apollo data sources to hook up your services to your graph API, you're also following best practices for organizing your code.
 
 In the next sections, we'll build data sources for a REST API and a SQL database and connect them to Apollo Server. Don't worry if you're not familiar with either of those technologies, you won't need to understand them deeply in order to follow the examples. 😀
 


### PR DESCRIPTION
At line 10,I think it should be Apollo data source API, as it is an explanation for the previous sentence. a data source API is different from data source, right?