### PR TITLE
Change --tag references to --variant for commands

### DIFF
--- a/docs/source/devtools/apollo-config.md
+++ b/docs/source/devtools/apollo-config.md
@@ -47,17 +47,17 @@ module.exports = {
 
 > **Note:** you must have a [registered schema](https://www.apollographql.com/docs/graph-manager/schema-registry/#registering-a-schema) for features like VS Code intellisense, which requires knowledge of your schema, to work properly.
 
-If you're tracking different versions of your schema in the registry using schema variants, you can link your client to a specific variant like so:
+If you're tracking different versions of your schema in the registry using graph variants, you can link your client to a specific variant like so:
 
 ```js{3}
 module.exports = {
   client: {
-    service: 'my-apollo-service@staging' // "staging" is the schema variant we're using
+    service: 'my-apollo-service@staging' // "staging" is the graph variant we're using
   }
 };
 ```
 
-If a schema variant is not specified, Apollo tools will fall back to the default value of `current`.
+If a graph variant is not specified, Apollo tools will fall back to the default value of `current`.
 
 #### _Option 2_: Link a schema from a remote endpoint
 

--- a/docs/source/devtools/editor-plugins.md
+++ b/docs/source/devtools/editor-plugins.md
@@ -138,9 +138,9 @@ Navigating large codebases can be difficult, but the Apollo GraphQL extension ma
 
 <img src="../img//editors/jump-to-def.gif" width="80%" style="margin: 5%" alt="Using jump to definition on a fragment">
 
-### Schema variant switching
+### Graph variant switching
 
-Apollo supports publishing multiple versions ([variants](https://www.apollographql.com/docs/graph-manager/schema-registry/#registering-a-schema-to-a-variant)) of a schema. This is useful for developing on a future development schema and preparing your clients to conform to that schema. To switch between schema variants, open the Command Palette (`cmd + shift + p` on mac), search "Apollo" and choose the "Apollo: Select Schema Tag" option.
+Apollo supports publishing multiple versions ([variants](https://www.apollographql.com/docs/graph-manager/schema-registry/#registering-a-schema-to-a-variant)) of a schema. This is useful for developing on a future development schema and preparing your clients to conform to that schema. To switch between graph variants, open the Command Palette (`cmd + shift + p` on mac), search "Apollo" and choose the "Apollo: Select Schema Tag" option.
 
 ## Troubleshooting
 

--- a/docs/source/devtools/editor-plugins.md
+++ b/docs/source/devtools/editor-plugins.md
@@ -16,7 +16,7 @@ The extension enables you to:
 - Validate field and argument usage in operations
 - [Navigate projects more easily](#navigating-projects) with jump-to and peek-at definitions
 - Manage [client-only](#client-only-schemas) schemas
-- [Switch schema tags](#schema-variant-switching) to work with schemas running on different environments
+- [Switch graph variants](#graph-variant-switching) to work with schemas running on different environments
 
 ## Getting started
 
@@ -70,7 +70,7 @@ module.exports = {
 };
 ```
 
-Linking to the local schema won't provide all features such as switching schema tags and performance metrics. See [the Apollo config docs][] for more details on configuration options.
+Linking to the local schema won't provide all features, such as switching graph variants and performance metrics. See [the Apollo config docs](./apollo-config/) for more details on configuration options.
 
 ### Client-only schemas
 
@@ -144,9 +144,7 @@ Apollo supports publishing multiple versions ([variants](https://www.apollograph
 
 ## Troubleshooting
 
-The most common errors are configuration errors, like a missing `.env` file or incorrect service information in the `apollo.config.js` file. Please see [the Apollo config docs][] for more configuration guidance.
-
-[the Apollo config docs]: https://www.apollographql.com/docs/references/apollo-config/
+The most common errors are configuration errors, like a missing `.env` file or incorrect service information in the `apollo.config.js` file. Please see [the Apollo config docs](./apollo-config/) for more configuration guidance.
 
 Other errors may be caused from an old version of a published schema. To reload a schema, open the Command Palette (`cmd + shift + p` on mac), search "Apollo" and choose the "Apollo: Reload Schema" option.
 

--- a/graph-manager-docs/source/managed-federation/advanced-topics.mdx
+++ b/graph-manager-docs/source/managed-federation/advanced-topics.mdx
@@ -11,54 +11,16 @@ To "de-register" an implementing service with Graph Manager, call `apollo servic
 
 > **This action cannot be reversed!**
 
-<<<<<<< HEAD:graph-manager-docs/source/managed-federation/advanced-topics.mdx
-=======
-1. [Register all federated services](#registering-federated-services) with the Apollo Graph Manager.
-1. [Configure Apollo Server](#connecting-apollo-server-to-graph-manager) as a gateway to connect to the graph manager.
-1. [Turn on metrics](#metrics-and-observability) for your federated graph.
-1. [Validate changes](#validating-changes-to-the-graph) to the graph against production traffic.
-1. [Integrate your federated graph](#integrating-with-your-deployment-pipeline) into your deployment pipeline.
-
-<!-- TODO: For current Apollo platform users looking to migrate their monolithic API to a federated graph, follow our [platform migration guide](#platform-migration-guide). -->
-
-## Core concepts
-
-Federation introduces several new terms that are necessary for understanding the following steps in this article:
-
-- **Graph**: A single API composed of multiple federated services
-- **Federated services**: The underlying microservices that make up a graph. These services are standalone GraphQL servers that can be built in any language, since [federation](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/) is spec-compliant GraphQL.
-- **Capabilities**: The types a service extends and adds to the graph. A service's capabilities describe how a service interacts with other portions of the graph.
-
-When you put these concepts together, a **graph** is composed of **federated services** that expose their **capabilities** in order to interact with each other.
-
-The rest of this article focuses on managing a federated graph with the Apollo platform. It assumes you've already implemented a federated graph. To implement a graph, read the [federation guide for Apollo Server](https://www.apollographql.com/docs/apollo-server/federation/introduction/) and come back to these steps once you're ready to run your graph in production.
-
-## Registering federated services
-
-If you're running a distributed GraphQL infrastructure, where federated services [compose](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#fetch-service-capabilities) to form a complete schema, tracking the history of the graph and its underlying services is essential. Running `apollo service:push` from within CI/CD on any federated service registers the overall schema of the graph and updates the graph's [managed configuration](#managed-configuration).
-
-To push a single federated service to Apollo, run `apollo service:push` in CI/CD with the `--serviceName`, `--endpoint`, and `--serviceURL` flags. The CLI will know where to fetch your service's capabilities based on the `--endpoint` flag, and the `--serviceURL` flag indicates where the federated service can be reached by the gateway. The `--serviceName` flag is used as a unique identifier for each federated service.
-
-Make sure you have a `.env` file locally with your `ENGINE_API_KEY` defined! To get an API key, click [here](https://engine.apollographql.com). To create a new `.env` file, copy your API key into the following command from your terminal:
-
-```bash
-echo "ENGINE_API_KEY=<your API key here>" >> .env
->>>>>>> Change --tag references to --variant for commands:graph-manager-docs/source/federation.mdx
 ```
 apollo service:delete --serviceName=products
 ```
 
 The next time it polls, your gateway obtains an updated configuration that reflects the removed service.
 
-Include the `--tag` option to remove an implementing service from a variant other than the default variant (`current`):
+Include the `--variant` option to remove an implementing service from a variant other than the default variant (`current`):
 
-<<<<<<< HEAD:graph-manager-docs/source/managed-federation/advanced-topics.mdx
 ```
-apollo service:delete --serviceName=products --tag=staging
-=======
-```bash
-apollo service:delete --serviceName=launches --variant=staging
->>>>>>> Change --tag references to --variant for commands:graph-manager-docs/source/federation.mdx
+apollo service:delete --serviceName=products --variant=staging
 ```
 
 ## Inspecting your graph

--- a/graph-manager-docs/source/managed-federation/advanced-topics.mdx
+++ b/graph-manager-docs/source/managed-federation/advanced-topics.mdx
@@ -11,6 +11,39 @@ To "de-register" an implementing service with Graph Manager, call `apollo servic
 
 > **This action cannot be reversed!**
 
+<<<<<<< HEAD:graph-manager-docs/source/managed-federation/advanced-topics.mdx
+=======
+1. [Register all federated services](#registering-federated-services) with the Apollo Graph Manager.
+1. [Configure Apollo Server](#connecting-apollo-server-to-graph-manager) as a gateway to connect to the graph manager.
+1. [Turn on metrics](#metrics-and-observability) for your federated graph.
+1. [Validate changes](#validating-changes-to-the-graph) to the graph against production traffic.
+1. [Integrate your federated graph](#integrating-with-your-deployment-pipeline) into your deployment pipeline.
+
+<!-- TODO: For current Apollo platform users looking to migrate their monolithic API to a federated graph, follow our [platform migration guide](#platform-migration-guide). -->
+
+## Core concepts
+
+Federation introduces several new terms that are necessary for understanding the following steps in this article:
+
+- **Graph**: A single API composed of multiple federated services
+- **Federated services**: The underlying microservices that make up a graph. These services are standalone GraphQL servers that can be built in any language, since [federation](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/) is spec-compliant GraphQL.
+- **Capabilities**: The types a service extends and adds to the graph. A service's capabilities describe how a service interacts with other portions of the graph.
+
+When you put these concepts together, a **graph** is composed of **federated services** that expose their **capabilities** in order to interact with each other.
+
+The rest of this article focuses on managing a federated graph with the Apollo platform. It assumes you've already implemented a federated graph. To implement a graph, read the [federation guide for Apollo Server](https://www.apollographql.com/docs/apollo-server/federation/introduction/) and come back to these steps once you're ready to run your graph in production.
+
+## Registering federated services
+
+If you're running a distributed GraphQL infrastructure, where federated services [compose](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#fetch-service-capabilities) to form a complete schema, tracking the history of the graph and its underlying services is essential. Running `apollo service:push` from within CI/CD on any federated service registers the overall schema of the graph and updates the graph's [managed configuration](#managed-configuration).
+
+To push a single federated service to Apollo, run `apollo service:push` in CI/CD with the `--serviceName`, `--endpoint`, and `--serviceURL` flags. The CLI will know where to fetch your service's capabilities based on the `--endpoint` flag, and the `--serviceURL` flag indicates where the federated service can be reached by the gateway. The `--serviceName` flag is used as a unique identifier for each federated service.
+
+Make sure you have a `.env` file locally with your `ENGINE_API_KEY` defined! To get an API key, click [here](https://engine.apollographql.com). To create a new `.env` file, copy your API key into the following command from your terminal:
+
+```bash
+echo "ENGINE_API_KEY=<your API key here>" >> .env
+>>>>>>> Change --tag references to --variant for commands:graph-manager-docs/source/federation.mdx
 ```
 apollo service:delete --serviceName=products
 ```
@@ -19,8 +52,13 @@ The next time it polls, your gateway obtains an updated configuration that refle
 
 Include the `--tag` option to remove an implementing service from a variant other than the default variant (`current`):
 
+<<<<<<< HEAD:graph-manager-docs/source/managed-federation/advanced-topics.mdx
 ```
 apollo service:delete --serviceName=products --tag=staging
+=======
+```bash
+apollo service:delete --serviceName=launches --variant=staging
+>>>>>>> Change --tag references to --variant for commands:graph-manager-docs/source/federation.mdx
 ```
 
 ## Inspecting your graph
@@ -309,12 +347,12 @@ For instance, in order to have a canary deployment, you might maintain two produ
 
 1. Check changes in "launches" against `prod` and `prod-canary`:
    ```
-   apollo service:check --tag=prod --serviceName=launches
-   apollo service:check --tag=prod-canary --serviceName=launches
+   apollo service:check --variant=prod --serviceName=launches
+   apollo service:check --variant=prod-canary --serviceName=launches
    ```
 1. Deploy changes to "launches" into your production environment. (_Note: This will not roll out changes to the gateway yet_)
-1. Roll over the `prod-canary` graph, containing one gateway container, using `apollo service:push --tag=prod-canary --serviceName=launches`. (_Note: If composition fails due to intermediate changes to the canary graph, new configuration will not be rolled out_)
+1. Roll over the `prod-canary` graph, containing one gateway container, using `apollo service:push --variant=prod-canary --serviceName=launches`. (_Note: If composition fails due to intermediate changes to the canary graph, new configuration will not be rolled out_)
 1. Wait for health checks to pass against the canary, watch dashboards, etc.
-1. After the canary is stable, roll out the changes to the rest of production using `apollo service:push --tag=prod --serviceName=launches`.
+1. After the canary is stable, roll out the changes to the rest of production using `apollo service:push --variant=prod --serviceName=launches`.
 
 Because you can [tag metrics with variants](/schema-registry/#associating-metrics-with-a-variant) as well, you can use [Apollo Graph Manager](https://engine.apollographql.com) to verify a canary's performance before rolling out changes to the rest of the graph. You can also use a similar strategy with variants to support a variety of other advanced deployment workflows, like blue/green deployments.

--- a/graph-manager-docs/source/operation-registry.mdx
+++ b/graph-manager-docs/source/operation-registry.mdx
@@ -122,7 +122,7 @@ If you encounter any errors, check the _**Troubleshooting**_ section below.
 
 #### 3.1 Optionally, set the graph variant
 
-To specify the schema variant to register operations on, pass an additional `--variant <VARIANT>` argument (`npx apollo client:push --variant <VARIANT>`).
+To specify the graph variant to register operations on, pass an additional `--variant <VARIANT>` argument (`npx apollo client:push --variant <VARIANT>`).
 
 ### 4. Disable subscription support on Apollo Server
 
@@ -469,7 +469,7 @@ Additionally, make sure that introspection is enabled on the server since intros
 
 ### Summary of changes
 
-The new release operation registry improves observability and robustness. These changes include: a [**stable operation manifest location**](#manifest-storage-location) based on a schema variant/tag rather than schema hash, registry [**metrics in the UI**](#metrics-and-usage-statistics), apollo [**client:push diagnostics**](#operation-registration-observability), and [**variant/tag awareness**](#varianttag-awareness).
+The new release operation registry improves observability and robustness. These changes include: a [**stable operation manifest location**](#manifest-storage-location) based on a graph variant/tag rather than schema hash, registry [**metrics in the UI**](#metrics-and-usage-statistics), apollo [**client:push diagnostics**](#operation-registration-observability), and [**variant/tag awareness**](#varianttag-awareness).
 
 These updates are designed to be transparent with a [smooth upgrade path](#upgrade-path). Since the operation manifest location has changed, all versions of `apollo client:push` double-write to the new and old storage locations, enabling seamless upgrade. Additionally the server's registry plugin can be upgraded immediately, because the plugin reads from the new location and uses the old location as a fallback, meaning the safelist will always be populated.
 
@@ -508,9 +508,9 @@ specific variant/tag, follow these steps:
 
 - **client**: Upgrade the `apollo` CLI package to 2.13.0 (by default the variant/tag will be set to the value in the [apollo config](https://www.apollographql.com/docs/references/apollo-config/#option-1-use-the-apollo-schema-registry))
 - **server**: Ensure that a schema has been published to the specified graph variant/tag.
-  This can be done by running `apollo service:push --variant <TAG>`
+  This can be done by running `apollo service:push --variant <VARIANT>`
 - **client**: Ensure that operations have been registered to the specified graph variant/tag.
-  This can be done by running `apollo client:push --variant <TAG>` or modifying the service in the `apollo.config.js`
+  This can be done by running `apollo client:push --variant <VARIANT>` or modifying the service in the `apollo.config.js`
 - **server**: Set the `schemaTag` field of `apollo-server-plugin-operation-registry` to the targeted graph variant/tag
 
 ```js

--- a/graph-manager-docs/source/operation-registry.mdx
+++ b/graph-manager-docs/source/operation-registry.mdx
@@ -79,7 +79,7 @@ When successful, this command should return output similar to the following:
 ✔ Fetching current schema
 ✔ Publishing <service> to Apollo Engine
 
-id      schema        tag
+id      schema        variant
 ------  ------------- -------
 abc123  <service>     current
 ```
@@ -120,9 +120,9 @@ Currently, once an operation is registered it will remain registered indefinitel
 
 If you encounter any errors, check the _**Troubleshooting**_ section below.
 
-#### 3.1 Optionally, set the schema tag
+#### 3.1 Optionally, set the graph variant
 
-To specify the schema tag to register operations on, pass an additional `--tag <TAG>` argument (`npx apollo client:push --tag <TAG>`).
+To specify the schema variant to register operations on, pass an additional `--variant <VARIANT>` argument (`npx apollo client:push --variant <VARIANT>`).
 
 ### 4. Disable subscription support on Apollo Server
 
@@ -213,9 +213,9 @@ const gateway = new ApolloGateway({
 
 </ExpansionPanel>
 
-#### 5.1 Optionally, set the schema tag
+#### 5.1 Optionally, set the graph variant (AKA schemaTag)
 
-Configure the `schemaTag` field to specify which tag to pull operation manifests from.
+Configure the `schemaTag` field to specify which graph variant to pull operation manifests from.
 
 ```js
 const server = new ApolloServer({
@@ -340,8 +340,8 @@ const server = new ApolloServer({
       willUpdateManifest(newManifest, oldManifest) {
         metrics.report(
           "safelist.numberOperations",
-          newManifest && 
-          newManifest.operations && 
+          newManifest &&
+          newManifest.operations &&
           newManifest.operations.length
         );
       }
@@ -508,9 +508,9 @@ specific variant/tag, follow these steps:
 
 - **client**: Upgrade the `apollo` CLI package to 2.13.0 (by default the variant/tag will be set to the value in the [apollo config](https://www.apollographql.com/docs/references/apollo-config/#option-1-use-the-apollo-schema-registry))
 - **server**: Ensure that a schema has been published to the specified graph variant/tag.
-  This can be done by running `apollo service:push --tag <TAG>`
+  This can be done by running `apollo service:push --variant <TAG>`
 - **client**: Ensure that operations have been registered to the specified graph variant/tag.
-  This can be done by running `apollo client:push --tag <TAG>` or modifying the service in the `apollo.config.js`
+  This can be done by running `apollo client:push --variant <TAG>` or modifying the service in the `apollo.config.js`
 - **server**: Set the `schemaTag` field of `apollo-server-plugin-operation-registry` to the targeted graph variant/tag
 
 ```js

--- a/graph-manager-docs/source/operation-registry.mdx
+++ b/graph-manager-docs/source/operation-registry.mdx
@@ -213,9 +213,9 @@ const gateway = new ApolloGateway({
 
 </ExpansionPanel>
 
-#### 5.1 Optionally, set the graph variant (AKA schemaTag)
+#### 5.1 Optionally, set the graph variant (AKA graphVariant)
 
-Configure the `schemaTag` field to specify which graph variant to pull operation manifests from.
+Configure the `graphVariant` field (`schemaTag` in `apollo-server` pre-2.13.0) to specify which graph variant to pull operation manifests from.
 
 ```js
 const server = new ApolloServer({

--- a/graph-manager-docs/source/schema-registry.mdx
+++ b/graph-manager-docs/source/schema-registry.mdx
@@ -73,7 +73,7 @@ jobs:
       # of the schema to Apollo Graph Manager.
       - run: |
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            apollo service:push --tag=master
+            apollo service:push --variant=master
           fi
 ```
 
@@ -95,13 +95,13 @@ Each variant of a graph functions as a standalone graph. It has its own change h
 
 ### Registering a schema to a variant
 
-To register a schema to a variant, include the `--tag=<VARIANT>` flag in your `apollo service:push` command, like so:
+To register a schema to a variant, include the `--variant=<VARIANT>` flag in your `apollo service:push` command, like so:
 
 ```bash
-apollo service:push --tag=beta
+apollo service:push --variant=beta
 ```
 
-If you omit the `--tag` flag, the `apollo service:push` command always pushes to the default graph variant, named `current`.
+If you omit the `--variant` flag, the `apollo service:push` command always pushes to the default graph variant, named `current`.
 
 ### Associating metrics with a variant
 

--- a/graph-manager-docs/source/schema-registry.mdx
+++ b/graph-manager-docs/source/schema-registry.mdx
@@ -107,14 +107,14 @@ If you omit the `--variant` flag, the `apollo service:push` command always pushe
 
 You can configure Apollo Server to associate the metrics it sends to Graph Manager with a particular variant. To do so, set the `ENGINE_SCHEMA_TAG` environment variable to the appropriate variant before initializing Apollo Server.
 
-Alternatively, you can include the `schemaTag` option in your call to the `ApolloServer` constructor, like so:
+Alternatively, you can include the `graphVariant` (`schemaTag` in `apollo-server` pre-2.13.0) option in your call to the `ApolloServer` constructor, like so:
 
 ```js
 const server = new ApolloServer({
   ...
   engine: {
     apiKey: "<ENGINE_API_KEY>",
-    schemaTag: "beta" // highlight-line
+    graphVariant: "beta" // highlight-line
   }
 });
 ```

--- a/graph-manager-docs/source/schema-validation.mdx
+++ b/graph-manager-docs/source/schema-validation.mdx
@@ -136,7 +136,7 @@ The output of `apollo service:check --markdown` looks like this:
 ```md
 ### Apollo Service Check
 
-🔄 Validated your local schema against schema tag `staging` on service `engine`.
+🔄 Validated your local schema against `engine@staging`.
 🔢 Compared **18 schema changes** against **100 operations** seen over the **last 24 hours**.
 ❌ Found **7 breaking changes** that would affect **3 operations** across **2 clients**
 

--- a/graph-manager-docs/source/schema-validation.mdx
+++ b/graph-manager-docs/source/schema-validation.mdx
@@ -40,7 +40,7 @@ Running `apollo service:check` outputs the diff of all detected schema changes  
 ```console
 $ npx apollo service:check
   ✔ Loading Apollo Project
-  ✔ Validated local schema against tag prod on service engine
+  ✔ Validated local schema against variant prod on service engine
   ✔ Compared 8 schema changes against 110 operations over the last 24 hours
   ✖ Found 3 breaking changes and 5 compatible changes
     → breaking changes found
@@ -114,7 +114,7 @@ jobs:
 
       # This command authenticates using the `ENGINE_API_KEY` environment
       # variable. Specify your GraphQL endpoint's URL in your Apollo config.
-      - run: npx apollo service:check --tag=staging
+      - run: npx apollo service:check --variant=staging
 ```
 
 ### Integrating with GitHub
@@ -147,10 +147,10 @@ The output of `apollo service:check --markdown` looks like this:
 
 You might want to validate your schema changes against multiple environments, such as production, staging, and beta. Each of these environments might have a slightly different schema to support features that are experimental or in active development. In Apollo Graph Manager, these schemas are represented as [variants](./schema-registry/#managing-environments-with-variants) of a single data graph.
 
-You can validate your schema against a particular variant by including the `--tag` flag in your call to `apollo service:check`, like so:
+You can validate your schema against a particular variant by including the `--variant` flag in your call to `apollo service:check`, like so:
 
 ```
-$ apollo service:check --tag=staging
+$ apollo service:check --variant=staging
 ```
 
 If you want to validate your schema against multiple variants, call `apollo service:check` once for each variant. Running `service:check` against multiple variants results in status checks similar to the following:
@@ -202,7 +202,7 @@ If you have any requests for other filtering or threshold mechanisms, please get
 
 ## Types of schema changes
 
-Not every change to a schema is a potentially breaking change. Additive changes (such as adding a field to a type) are typically safe and do not affect active clients. Deletions and modifications (such as removing a field or changing a return type), however, can break clients that use affected types and fields. 
+Not every change to a schema is a potentially breaking change. Additive changes (such as adding a field to a type) are typically safe and do not affect active clients. Deletions and modifications (such as removing a field or changing a return type), however, can break clients that use affected types and fields.
 
 ### Potentially breaking changes
 


### PR DESCRIPTION
This is to support a change to the command line tool to prefer using
--variant to --tag and deprecate the latter. Please see https://github.com/apollographql/apollo-tooling/pull/1849 for reference! We should correspond timing of the two :)