### PR TITLE
[DO NOT MERGE] Support APOLLO_KEY in favor of ENGINE_API_KEY

### DIFF
--- a/docs/source/devtools/editor-plugins.md
+++ b/docs/source/devtools/editor-plugins.md
@@ -50,7 +50,7 @@ To authenticate with Graph Manager to pull down the schema, create a file next t
 After the key is found, add the following line to the `.env` file:
 
 ```bash
-ENGINE_API_KEY=<enter copied key here>
+APOLLO_KEY=<enter copied key here>
 ```
 
 After this is done, VS Code can be reloaded and the Apollo integration will connect to Graph Manager to provide autocomplete, validation, and more.

--- a/docs/source/tutorial/client.mdx
+++ b/docs/source/tutorial/client.mdx
@@ -33,16 +33,16 @@ While Apollo VSCode is not required to successfully complete the tutorial, setti
 First, make a copy of the `.env.example` file located in `client/` and call it `.env`. Add your Graph Manager API key that you already created in step #4 to the file:
 
 ```
-ENGINE_API_KEY=service:<your-service-name>:<hash-from-apollo-engine>
+APOLLO_KEY=service:<your-service-name>:<hash-from-apollo-engine>
 ```
 
 The entry should basically look something like this:
 
 ```
-ENGINE_API_KEY=service:my-service-439:E4VSTiXeFWaSSBgFWXOiSA
+APOLLO_KEY=service:my-service-439:E4VSTiXeFWaSSBgFWXOiSA
 ```
 
-Our key is now stored under the environment variable `ENGINE_API_KEY`. Apollo VSCode uses this API key to pull down your schema from the registry.
+Our key is now stored under the environment variable `APOLLO_KEY`. Apollo VSCode uses this API key to pull down your schema from the registry.
 
 Next, create an Apollo config file called `apollo.config.js`. This config file is how you configure both the Apollo VSCode extension and CLI. Paste the snippet below into the file:
 
@@ -59,7 +59,7 @@ Great, we're all set up! Let's dive into building our first client.
 
 ## Create an Apollo Client
 
-<Disclaimer /> 
+<Disclaimer />
 
 Now that we have installed the necessary packages, let's create an `ApolloClient` instance.
 
@@ -151,7 +151,7 @@ import { InMemoryCache, NormalizedCacheObject } from 'apollo-cache-inmemory'; //
 import { HttpLink } from 'apollo-link-http'; // preserve-line
 import { ApolloProvider } from '@apollo/react-hooks';
 import React from 'react';
-import ReactDOM from 'react-dom'; 
+import ReactDOM from 'react-dom';
 import Pages from './pages';
 import injectStyles from './styles';
 
@@ -161,7 +161,7 @@ injectStyles();
 ReactDOM.render(
   <ApolloProvider client={client}>
     <Pages />
-  </ApolloProvider>, 
+  </ApolloProvider>,
   document.getElementById('root')
 );
 ```

--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -22,16 +22,16 @@ First, we need an Apollo Graph Manager API key. Navigate to [Apollo Graph Manage
 Let's save our key as an environment variable. It's important to make sure we don't check our Graph Manager API key into version control. Go ahead and make a copy of the `.env.example` file located in `server/` and call it `.env`. Add your Graph Manager API key that you copied from the previous step to the file:
 
 ```
-ENGINE_API_KEY=service:<your-service-name>:<hash-from-apollo-engine>
+APOLLO_KEY=service:<your-service-name>:<hash-from-apollo-engine>
 ```
 
 The entry should basically look like this:
 
 ```
-ENGINE_API_KEY=service:my-service-439:E4VSTiXeFWaSSBgFWXOiSA
+APOLLO_KEY=service:my-service-439:E4VSTiXeFWaSSBgFWXOiSA
 ```
 
-Our key is now stored under the environment variable `ENGINE_API_KEY`.
+Our key is now stored under the environment variable `APOLLO_KEY`.
 
 ### Check and publish with the Apollo CLI
 

--- a/graph-manager-docs/source/federation.mdx
+++ b/graph-manager-docs/source/federation.mdx
@@ -37,10 +37,10 @@ If you're running a distributed GraphQL infrastructure, where federated services
 
 To push a single federated service to Apollo, run `apollo service:push` in CI/CD with the `--serviceName`, `--endpoint`, and `--serviceURL` tags. The CLI will know where to fetch your service's capabilities based on the `--endpoint` flag, and the `--serviceURL` flag indicates where the federated service can be reached by the gateway. The `--serviceName` flag is used as a unique identifier for each federated service.
 
-Make sure you have a `.env` file locally with your `ENGINE_API_KEY` defined! To get an API key, click [here](https://engine.apollographql.com). To create a new `.env` file, copy your API key into the following command from your terminal:
+Make sure you have a `.env` file locally with your `APOLLO_KEY` defined! To get an API key, click [here](https://engine.apollographql.com). To create a new `.env` file, copy your API key into the following command from your terminal:
 
 ```bash
-echo "ENGINE_API_KEY=<your API key here>" >> .env
+echo "APOLLO_KEY=<your API key here>" >> .env
 ```
 
 As an example, running service push on a “launches” federated service might look like:
@@ -96,9 +96,9 @@ Federation is made up of two parts: federated services and a **gateway** to comp
 
 While running in development, it's sufficient to run the gateway with a static service list and use introspection to support the gateway's configuration. When running a gateway in production, however, it's important that the uptime of your gateway is not impacted by the uptime of the federated services beneath it. If a gateway fails to introspect a service or if a service fails to compose with the graph, it's paramount that your gateway be resilient to that change and continue to serve traffic with its previous configuration.
 
-For this use case, an Apollo gateway can be created to pick up its configuration from a set of managed files, securely stored during [service registration](#registering-federated-services).  To use the managed configuration provisioned by [Graph Manager](https://engine.apollographql.com), obtain an API key from the Settings page and set the `ENGINE_API_KEY` environment variable to that key.
+For this use case, an Apollo gateway can be created to pick up its configuration from a set of managed files, securely stored during [service registration](#registering-federated-services).  To use the managed configuration provisioned by [Graph Manager](https://engine.apollographql.com), obtain an API key from the Settings page and set the `APOLLO_KEY` environment variable to that key.
 
-> If you're already setting the `engine` property of [the `ApolloServer` constructor options](https://www.apollographql.com/docs/apollo-server/api/apollo-server/) and have included the API key in those settings, you can skip setting the `ENGINE_API_KEY` value in the environment.
+> If you're already setting the `engine` property of [the `ApolloServer` constructor options](https://www.apollographql.com/docs/apollo-server/api/apollo-server/) and have included the API key in those settings, you can skip setting the `APOLLO_KEY` value in the environment.
 
 Then, construct the gateway and `ApolloServer` like so:
 
@@ -287,7 +287,7 @@ With this atomic strategy, the query planner resolves all outstanding requests t
 
 Like any distributed architecture, you should make sure that your federated graph has proper observability, monitoring, and automation to ensure reliability and performance of both your gateway and the federated services underneath it. Serving your GraphQL API from a distributed architecture has many benefits, like productivity, isolation, and being able to match the right services with the right runtimes. Operating a distributed system also has more complexity and points of failure than operating a monolith, and with that complexity comes a need to heighten observability into the state of your system and control over its coordination.
 
-Apollo Server has support for reporting federated [tracing](/performance/) information from the gateway. In order to support the gateway with detailed timing and error information, federated services expose their own tracing information per-fetch in their extensions, which are consumed by the gateway and merged together in order to be emitted to the Apollo metrics ingress. To enable this functionality, make sure the `ENGINE_API_KEY` is set in the environment for your gateway server and ensure that all federated services and the gateway are running `apollo-server` version `2.7.0` or greater. Also, ensure that federated services do not have the `ENGINE_API_KEY` environment variable set.
+Apollo Server has support for reporting federated [tracing](/performance/) information from the gateway. In order to support the gateway with detailed timing and error information, federated services expose their own tracing information per-fetch in their extensions, which are consumed by the gateway and merged together in order to be emitted to the Apollo metrics ingress. To enable this functionality, make sure the `APOLLO_KEY` is set in the environment for your gateway server and ensure that all federated services and the gateway are running `apollo-server` version `2.7.0` or greater. Also, ensure that federated services do not have the `APOLLO_KEY` environment variable set.
 
 Traces will be reported in the shape of the query plan, with each unique fetch to a federated service reporting timing and error data.
 

--- a/graph-manager-docs/source/github-integration.md
+++ b/graph-manager-docs/source/github-integration.md
@@ -41,7 +41,7 @@ jobs:
       # commands against it
       - run: sleep 5
 
-      # This will authenticate using the `ENGINE_API_KEY` environment
+      # This will authenticate using the `APOLLO_KEY` environment
       # variable. If the GraphQL server is available elsewhere than
       # http://localhost:4000/graphql, set it with `--endpoint=<URL>`.
       - run: apollo service:check

--- a/graph-manager-docs/source/operation-registry.mdx
+++ b/graph-manager-docs/source/operation-registry.mdx
@@ -64,11 +64,11 @@ npm install apollo --save-dev
 
 First, make sure Apollo Server is running and that introspection is enabled (it is often disabled in production).
 
-Next, using the following command as a reference, replace the `<ENGINE_API_KEY>` with the Apollo Graph Manager API key from the appropriate service and specify the correct server endpoint with the `--endpoint` flag:
+Next, using the following command as a reference, replace the `<APOLLO_KEY>` with the Apollo Graph Manager API key from the appropriate service and specify the correct server endpoint with the `--endpoint` flag:
 
 ```
 npx apollo service:push               \
-    --key <ENGINE_API_KEY>            \
+    --key <APOLLO_KEY>            \
     --endpoint https://server/graphql
 ```
 
@@ -97,11 +97,11 @@ The `apollo client:push` command:
 - Accepts a list of files as a glob (e.g. `src/**/*.ts`) to search for GraphQL operations.
 - By default, includes the `__typename` fields which are added by Apollo Client at runtime.  (Add the `--no-addTypeName` flag to disable this behavior.)
 
-To register operations, use the following command as a reference, taking care to replace the `<ENGINE_API_KEY>` with the appropriate Apollo Graph Manager API key, specifying a unique name for this application with `<CLIENT_IDENTIFIER>`, and indicating the correct glob of files to search:
+To register operations, use the following command as a reference, taking care to replace the `<APOLLO_KEY>` with the appropriate Apollo Graph Manager API key, specifying a unique name for this application with `<CLIENT_IDENTIFIER>`, and indicating the correct glob of files to search:
 
 ```
 npx apollo client:push \
-    --key <ENGINE_API_KEY> \
+    --key <APOLLO_KEY> \
     --clientName <CLIENT_IDENTIFIER> \
     --clientVersion <CLIENT_VERSION> \
     --includes="src/**/*.{ts,js,graphql}"
@@ -232,10 +232,10 @@ const server = new ApolloServer({
 
 If the server was already configured to use Apollo Graph Manager, no additional changes are necessary, but it's important to make sure that the server is configured to use the same service as the operations were registered with in step 3.
 
-If the server was not previously configured with Apollo Graph Manager, be sure to start the server with the `ENGINE_API_KEY` variable set to the appropriate API key. For example:
+If the server was not previously configured with Apollo Graph Manager, be sure to start the server with the `APOLLO_KEY` variable set to the appropriate API key. For example:
 
 ```
-ENGINE_API_KEY=<ENGINE_API_KEY> npm start
+APOLLO_KEY=<APOLLO_KEY> npm start
 ```
 
 Alternatively, the API key can be specified with the `engine` parameter on the Apollo Server constructor options:
@@ -243,7 +243,7 @@ Alternatively, the API key can be specified with the `engine` parameter on the A
 ```js
 const server = new ApolloServer({
   // ...
-  engine: '<ENGINE_API_KEY>', // highlight-line
+  engine: '<APOLLO_KEY>', // highlight-line
   // ...
 });
 ```
@@ -290,7 +290,7 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   subscriptions: false,
-  engine: '<ENGINE_API_KEY>',
+  engine: '<APOLLO_KEY>',
   plugins: [
     require('apollo-server-plugin-operation-registry')({
       // De-structure the object to get the HTTP `headers` and the GraphQL
@@ -340,8 +340,8 @@ const server = new ApolloServer({
       willUpdateManifest(newManifest, oldManifest) {
         metrics.report(
           "safelist.numberOperations",
-          newManifest && 
-          newManifest.operations && 
+          newManifest &&
+          newManifest.operations &&
           newManifest.operations.length
         );
       }

--- a/graph-manager-docs/source/schema-registry.mdx
+++ b/graph-manager-docs/source/schema-registry.mdx
@@ -109,7 +109,7 @@ Alternatively, you can include the `schemaTag` option in your call to the `Apoll
 const server = new ApolloServer({
   ...
   engine: {
-    apiKey: "<ENGINE_API_KEY>",
+    apiKey: "<APOLLO_KEY>",
     schemaTag: "beta" // highlight-line
   }
 });

--- a/graph-manager-docs/source/schema-validation.mdx
+++ b/graph-manager-docs/source/schema-validation.mdx
@@ -114,7 +114,7 @@ jobs:
       # commands against it.
       - run: sleep 5
 
-      # This command authenticates using the `ENGINE_API_KEY` environment
+      # This command authenticates using the `APOLLO_KEY` environment
       # variable. Specify your GraphQL endpoint's URL in your Apollo config.
       - run: npx apollo service:check --tag=staging
 ```
@@ -204,7 +204,7 @@ If you have any requests for other filtering or threshold mechanisms, please get
 
 ## Types of schema changes
 
-Not every change to a schema is a potentially breaking change. Additive changes (such as adding a field to a type) are typically safe and do not affect active clients. Deletions and modifications (such as removing a field or changing a return type), however, can break clients that use affected types and fields. 
+Not every change to a schema is a potentially breaking change. Additive changes (such as adding a field to a type) are typically safe and do not affect active clients. Deletions and modifications (such as removing a field or changing a return type), however, can break clients that use affected types and fields.
 
 ### Potentially breaking changes
 

--- a/graph-manager-docs/source/setup-analytics.md
+++ b/graph-manager-docs/source/setup-analytics.md
@@ -32,7 +32,7 @@ server.listen().then(({ url }) => {
 });
 ```
 
-Alternatively, you can specify your API key as the value of the `ENGINE_API_KEY` environment variable in the environment where Apollo Server will run.
+Alternatively, you can specify your API key as the value of the `APOLLO_KEY` environment variable in the environment where Apollo Server will run.
 
 This is the only change required to begin sending traces to Graph Manager. For advanced configuration options, see [Metrics and logging](https://www.apollographql.com/docs/apollo-server/features/metrics/).
 
@@ -53,7 +53,7 @@ Apollo Server defines its agent for performing these tasks in [`agent.ts`](https
 
 Graph Manager's reporting endpoint accepts batches of traces that are encoded in **protocol buffer** format. Each trace corresponds to the execution of a single GraphQL operation, including a breakdown of the timing and error information for each field that's resolved as part of the operation.
 
-The schema for this protocol buffer is defined as the `FullTracesReport` message in the [TypeScript reference implementation](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-engine-reporting-protobuf/src/reports.proto#L466). 
+The schema for this protocol buffer is defined as the `FullTracesReport` message in the [TypeScript reference implementation](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-engine-reporting-protobuf/src/reports.proto#L466).
 
 As a starting point, we recommend implementing an extension to the GraphQL execution that creates a report with a single trace, as defined in the `Trace` message of [the protobuf schema](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-engine-reporting-protobuf/src/reports.proto#L7). Then, you can batch multiple traces into a single report. We recommend sending batches approximately every 20 seconds, and limiting each batch to a reasonable size (~4MB).
 


### PR DESCRIPTION
We are moving to a new key format (the prior format of ENGINE_API_KEY
will still work, but will provide a deprecation notice). This commit
updates all non-engineproxy references to refer to APOLLO_KEY instead of
ENGINE_API_KEY.

Blocked by release of https://github.com/apollographql/apollo-tooling/pull/1851
Blocked by release of https://github.com/apollographql/apollo-server/pull/3923
Related to https://github.com/apollographql/apollo/pull/823
as well as release of <APOLLO_SERVER_PR_HERE>

This still has some steps left, but I wanted to open it up to make sure I'm
tracking all the right ones!

TODO:
 - [ ] Update any related Apollo Server docs
 - [ ] Include notice about older versions of Apollo Server (e.g. if you're using a version pre-2.9.1, please set ENGINE_API_KEY instead)
 - [ ] Get associated CLI and Apollo Server pieces released