### PR TITLE
Update tutorial with step on adding `apollo-config.js` 

### DIFF
--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -33,6 +33,16 @@ ENGINE_API_KEY=service:my-service-439:E4VSTiXeFWaSSBgFWXOiSA
 
 Our key is now stored under the environment variable `ENGINE_API_KEY`.
 
+Next, you'll need to create a file called `apollo.config.js` in the `./src` folder with the following configuration:
+
+```
+module.exports = {
+  service: {
+    name: <your-service-name>
+  }
+}
+```
+
 ### Check and publish with the Apollo CLI
 
 It's time to publish our schema to Graph Manager! First, start your server in one terminal window by running `npm start`. In another terminal window, run:


### PR DESCRIPTION
The tutorial is currently out of date with regards to publish schemas to Apollo Graph Manager. The step about adding an `apollo-config.js` file with your service name is missing,  which causes errors when running `npx apollo service:push --endpoint=http://localhost:4000`.

Error: 
```
 Error: No graph (i.e. service) found
 ›   to link to Apollo Graph Manager.
 ›   In order to run this command, please
 ›   provide a graph ID using the
 ›   'apollo.config.js' file.
 ›
 ›
 ›   For more information on configuring
 ›   the Apollo CLI, please go to
 ›   https://go.apollo.dev/t/config
```

There's a few issues on this so I thought I'd set up a PR to fix this.
