### PR TITLE
Fix titles in tutorial code blocks.

### DIFF
--- a/docs/source/tutorial/client.mdx
+++ b/docs/source/tutorial/client.mdx
@@ -32,13 +32,13 @@ While Apollo VSCode is not required to successfully complete the tutorial, setti
 
 First, make a copy of the `.env.example` file located in `client/` and call it `.env`. Add your Graph Manager API key that you already created in step #4 to the file:
 
-```
+```bash:title=.env
 ENGINE_API_KEY=service:<your-service-name>:<hash-from-apollo-engine>
 ```
 
 The entry should basically look something like this:
 
-```
+```bash:title=.env
 ENGINE_API_KEY=service:my-service-439:E4VSTiXeFWaSSBgFWXOiSA
 ```
 
@@ -46,7 +46,7 @@ Our key is now stored under the environment variable `ENGINE_API_KEY`. Apollo VS
 
 Next, create an Apollo config file called `apollo.config.js`. This config file is how you configure both the Apollo VSCode extension and CLI. Paste the snippet below into the file:
 
-```js
+```js:title=apollo.config.js
 module.exports = {
   client: {
     name: 'Space Explorer [web]',

--- a/docs/source/tutorial/data-source.md
+++ b/docs/source/tutorial/data-source.md
@@ -23,9 +23,7 @@ This package exposes the `RESTDataSource` class that is responsible for fetching
 
 In our example, the `baseURL` for our API is `https://api.spacexdata.com/v2/`. Let's create our `LaunchAPI` data source by adding the code below to `src/datasources/launch.js`:
 
-_src/datasources/launch.js_
-
-```js
+```js:title=src/datasources/launch.js
 const { RESTDataSource } = require('apollo-datasource-rest');
 
 class LaunchAPI extends RESTDataSource {
@@ -44,9 +42,7 @@ The Apollo `RESTDataSource` also sets up an in-memory cache that caches response
 
 The next step is to add methods to the `LaunchAPI` data source that correspond to the queries our graph API needs to fetch. According to our schema, we'll need a method to get all of the launches. Let's add a `getAllLaunches` method to our `LaunchAPI` class now:
 
-_src/datasources/launch.js_
-
-```js
+```js:title=src/datasources/launch.js
 async getAllLaunches() {
   const response = await this.get('launches');
   return Array.isArray(response)
@@ -59,9 +55,7 @@ The Apollo REST data sources have helper methods that correspond to HTTP verbs l
 
 Now, we need to write our `launchReducer` method in order to transform our launch data into the shape our schema expects. We recommend this approach in order to decouple your graph API from business logic specific to your REST API. First, let's recall what our `Launch` type looks like in our schema. You don't have to copy this code:
 
-_src/schema.js_
-
-```graphql
+```graphql:title=src/schema.js
 type Launch {
   id: ID!
   site: String
@@ -73,9 +67,7 @@ type Launch {
 
 Next, let's write a `launchReducer` function to transform the data into that shape. Copy the following code into your `LaunchAPI` class:
 
-_src/datasources/launch.js_
-
-```js
+```js:title=src/datasources/launch.js
 launchReducer(launch) {
   return {
     id: launch.flight_number || 0,
@@ -99,9 +91,7 @@ With the above changes, we can easily make changes to the `launchReducer` method
 
 Next, let's take care of fetching a specific launch by its ID. Let's add two methods, `getLaunchById`, and `getLaunchesByIds` to the `LaunchAPI` class.
 
-_src/datasources/launch.js_
-
-```js
+```js:title=src/datasources/launch.js
 async getLaunchById({ launchId }) {
   const response = await this.get('launches', { flight_number: launchId });
   return this.launchReducer(response[0]);
@@ -146,9 +136,7 @@ Now that we've built our `LaunchAPI` data source to connect our REST API and our
 
 Adding our data sources is simple. Just create a `dataSources` property on your `ApolloServer` that corresponds to a function that returns an object with your instantiated data sources. Let's see what that looks like by navigating to `src/index.js` and adding the code below:
 
-_src/index.js_
-
-```js{3,5,6,8,12-15}
+```js{3,5,6,8,12-15}:title=src/index.js
 const { ApolloServer } = require('apollo-server');
 const typeDefs = require('./schema');
 const { createStore } = require('./utils');

--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -21,13 +21,13 @@ First, we need an Apollo Graph Manager API key. Navigate to [Apollo Graph Manage
 
 Let's save our key as an environment variable. It's important to make sure we don't check our Graph Manager API key into version control. Go ahead and make a copy of the `.env.example` file located in `server/` and call it `.env`. Add your Graph Manager API key that you copied from the previous step to the file:
 
-```
+```bash:title=.env
 ENGINE_API_KEY=service:<your-service-name>:<hash-from-apollo-engine>
 ```
 
 The entry should basically look like this:
 
-```
+```bash:title=.env
 ENGINE_API_KEY=service:my-service-439:E4VSTiXeFWaSSBgFWXOiSA
 ```
 

--- a/docs/source/tutorial/resolvers.md
+++ b/docs/source/tutorial/resolvers.md
@@ -30,8 +30,7 @@ This might sound confusing at first, but it will start to make more sense once w
 
 First, let's connect our resolver map to Apollo Server. Right now, it's just an empty object, but we should add it to our `ApolloServer` instance so we don't have to do it later. Navigate to `src/index.js` and add the following code to the file:
 
-_src/index.js_
-```js
+```js:title=src/index.js
 const { ApolloServer } = require('apollo-server');
 const typeDefs = require('./schema');
 const { createStore } = require('./utils');
@@ -64,9 +63,7 @@ First, let's start by writing our resolvers for the `launches`, `launch`, and `m
 
 Navigate to `src/resolvers.js` and paste the code below into the file:
 
-_src/resolvers.js_
-
-```js
+```js:title=src/resolvers.js
 module.exports = {
   Query: {
     launches: (_, __, { dataSources }) =>
@@ -141,9 +138,7 @@ Running the `launches` query returned a large data set of launches, which can sl
 
 We'll use cursor-based pagination for our graph API. Open up the `src/schema.js` file and update the `Query` type with `launches` and also add a new type called `LaunchConnection` to the schema as shown below:
 
-_src/schema.js_
-
-```graphql
+```graphql:title=src/schema.js
 type Query {
   launches( # replace the current launches query with this one.
     """
@@ -177,9 +172,7 @@ Open up the `src/utils.js` file and check out the `paginateResults` function. Th
 
 Let's import `paginateResults` and replace the `launches` resolver function in the `src/resolvers.js` file with the code below:
 
-_src/resolvers.js_
-
-```js{1,5-26}
+```js{1,5-26}:title=src/resolvers.js
 const { paginateResults } = require('./utils');
 
 module.exports = {
@@ -239,9 +232,7 @@ You may have noticed that we haven't written resolvers for all our types, yet ou
 
 Let's look at a case where we do want to write a resolver on our `Mission` type. Navigate to `src/resolvers.js` and copy this resolver into our resolver map underneath the `Query` property:
 
-_src/resolvers.js_
-
-```js
+```js:title=src/resolvers.js
 Mission: {
   // make sure the default size is 'large' in case user doesn't specify
   missionPatch: (mission, { size } = { size: 'LARGE' }) => {
@@ -252,8 +243,7 @@ Mission: {
 },
 ```
 
-_src/schema.js_
-```js
+```js:title=src/schema.js
   type Mission {
     # ... with rest of schema
     missionPatch(mission: String, size: PatchSize): String
@@ -264,9 +254,7 @@ The first argument passed into our resolver is the parent, which refers to the m
 
 Now that we know how to add resolvers on types other than `Query` and `Mission`, let's add some more resolvers to the `Launch` and `User` types. Copy this code into your resolver map:
 
-_src/resolvers.js_
-
-```js
+```js:title=src/resolvers.js
 Launch: {
   isBooked: async (launch, _, { dataSources }) =>
     dataSources.userAPI.isBookedOnLaunch({ launchId: launch.id }),
@@ -302,9 +290,7 @@ Here are the steps you'll want to follow:
 
 Let's open up `src/index.js` and update the `context` function on `ApolloServer` to the code shown below:
 
-_src/index.js_
-
-```js{1,4,8,10}
+```js{1,4,8,10}:src/index.js
 const isEmail = require('isemail');
 
 const server = new ApolloServer({
@@ -332,9 +318,7 @@ How do we create the token passed to the `authorization` headers? Let's move on 
 
 Writing `Mutation` resolvers is similar to the resolvers we've already written. First, let's write the `login` resolver to complete our authentication flow. Add the code below to your resolver map underneath the `Query` resolvers:
 
-_src/resolvers.js_
-
-```js
+```js:title=src/resolvers.js
 Mutation: {
   login: async (_, { email }, { dataSources }) => {
     const user = await dataSources.userAPI.findOrCreateUser({ email });
@@ -347,9 +331,7 @@ The `login` resolver receives an email address and returns a token if a user exi
 
 Now, let's add the resolvers for `bookTrips` and `cancelTrip` to `Mutation`:
 
-_src/resolvers.js_
-
-```js
+```js:title=src/resolvers.js
 Mutation: {
   bookTrips: async (_, { launchIds }, { dataSources }) => {
     const results = await dataSources.userAPI.bookTrips({ launchIds });


### PR DESCRIPTION
I noticed that some of the tutorial code block titles were inconsistent, so here's a small PR that fixes those inconsistencies. Related to [this PR](https://github.com/apollographql/gatsby-theme-apollo/pull/115).

Before:
![image](https://user-images.githubusercontent.com/10587608/80655300-4cde3500-8a4c-11ea-983b-4fb1516722f9.png)

After:
![image](https://user-images.githubusercontent.com/10587608/80655314-54054300-8a4c-11ea-9aed-21075e65e1d3.png)
