### PR TITLE
Tutorial docs fix: remove `mission` argument from `missionPatch`

### DIFF
--- a/docs/source/tutorial/resolvers.md
+++ b/docs/source/tutorial/resolvers.md
@@ -256,7 +256,7 @@ _src/schema.js_
 ```js
   type Mission {
     # ... with rest of schema
-    missionPatch(mission: String, size: PatchSize): String
+    missionPatch(size: PatchSize): String
   }
 ```
 


### PR DESCRIPTION
The resolver *does* take `mission` as its first argument (since the mission is the parent of the mission patch), but the `missionPatch` field in the type definition for `Mission` should not take a `mission` argument.

Fixes #532