### PR TITLE
Update client.mdx

### DIFF
--- a/docs/source/tutorial/client.mdx
+++ b/docs/source/tutorial/client.mdx
@@ -24,18 +24,22 @@ Now, our dependencies are installed. Here are the packages we will be using to b
 
 - `apollo-client`: A complete data management solution with an intelligent cache. In this tutorial, we will be using the Apollo Client 3.0 preview since it includes local state management capabilities and sets your cache up for you.
 - `react-apollo`: The view layer integration for React that exports components such as `Query` and `Mutation`
-- `graphql-tag`: The tag function `gql` that we use to wrap our query strings in order to parse them into an AST
+- `graphql-tag`: The tag function `gql` that we use to wrap our query strings in order to parse them into an Abstract Syntax Tree (AST). An Abstract Syntax Tree is just a fancy label for an object with lots of nested objects.
 
-### Configure Apollo VSCode
+### Configure the Apollo GraphQL VSCode Extension
 
-While Apollo VSCode is not required to successfully complete the tutorial, setting it up unlocks a lot of helpful features such as autocomplete for operations, jump to fragment definitions, and more.
+While the [Apollo GraphQL VSCode extension](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) is not required to successfully complete the tutorial, setting it up unlocks a lot of helpful features such as autocomplete for operations, jump to fragment definitions, and more.
 
-First, make a copy of the `.env.example` file located in `client/` and call it `.env`. Add your Graph Manager API key that you already created in step #4 to the file:
-> Note: You may need to upgrade your plugin version, which relies on the former `ENGINE_API_KEY` environment variable
+This setup will only work if you published a Graph Manager API in step #5.
+
+First, make a copy of the `.env.example` file located in `client/` and call it `.env`. 
+
+From the [Graph Manager Engine](https://engine.apollographql.com) screen, click on the API that you published, and click "Settings" in the left hand side. In the "API Keys" section, there is a table of Tokens. In the first row, click on the three dots at the far right and click "Copy Token". You will use this token for your `APOLLO_KEY` like so:
 
 ```bash:title=.env
 APOLLO_KEY=service:<your-service-name>:<hash-from-apollo-engine>
 ```
+> Note: You may need to upgrade your plugin version, which formerly relied on the `ENGINE_API_KEY` environment variable
 
 The entry should basically look something like this:
 
@@ -43,7 +47,7 @@ The entry should basically look something like this:
 APOLLO_KEY=service:my-service-439:E4VSTiXeFWaSSBgFWXOiSA
 ```
 
-Our key is now stored under the environment variable `APOLLO_KEY`. Apollo VSCode uses this API key to pull down your schema from the registry.
+Our key is now stored under the environment variable `APOLLO_KEY`. The Apollo GraphQL VSCode extension uses this API key to pull down your schema from the registry.
 
 Next, create an Apollo config file called `apollo.config.js`. This config file is how you configure both the Apollo VSCode extension and CLI. Paste the snippet below into the file:
 
@@ -51,10 +55,25 @@ Next, create an Apollo config file called `apollo.config.js`. This config file i
 module.exports = {
   client: {
     name: 'Space Explorer [web]',
-    service: 'space-explorer',
+    service: '<your-service-name>',
   },
 };
 ```
+
+To continue with the example above, it would look something like this (Note: the `name` field doesn't matter):
+
+```js:title=apollo.config.js
+module.exports = {
+  client: {
+    name: 'Space Explorer [web]',
+    service: 'my-service-439',
+  },
+};
+```
+
+Finally, install the [Apollo GraphQL VSCode extension](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) however you prefer to install plugins. You may need to reload the window for the extension to take effect.
+
+If the extension complains about not being able to get to `space-explorer` that's because it found the `apollo.config.js` files in the `/final/` directory. You can quiet these errors by simply renaming those two files `apollo.config.js.example`.
 
 Great, we're all set up! Let's dive into building our first client.
 
@@ -64,9 +83,9 @@ Great, we're all set up! Let's dive into building our first client.
 
 Now that we have installed the necessary packages, let's create an `ApolloClient` instance.
 
-Navigate to `src/index.tsx` so we can create our client. The `uri` that we pass in is the graph endpoint from the service you deployed in step 4.
+Navigate to `src/index.tsx` so we can create our client. The `uri` that we pass in is the graph endpoint from the service you deployed in step 5.
 
-If you didn't complete the server portion, you can use the `uri` from the code below. Otherwise, use your own deployment's URL, which may be different than the one below. Navigate to `src/index.tsx` and copy the code below:
+If you didn't publish an API in Graph Mananger, you can use `http://localhost:4000/` as the `uri` as shown below. Otherwise, use your own deployment's URL, which may be different than the one below. Navigate to `src/index.tsx` and copy the code below:
 
 <MultiCodeBlock>
 


### PR DESCRIPTION
I'm proposing the following changes to the client tutorial, based on things that tripped me up:

- Explaining what an AST is, albeit briefly
- An extensive re-write of the section on getting the VSCode extension up and running. There were several issues with that section, such as the extension not being named fully (so as to make it clear when searching for the extension in the marketplace). Also, the `space-explorer` service doesn't work anymore (I don't know, but I wonder if it was a publicly available service once upon a time), so I am suggesting people use their own service name (this is what worked for me in local testing anyway). I also tell people to, you know, _install_ the extension. 
- Lastly I explain more fully that they can use `localhost` in the text about setting up the `uri`.