### PR TITLE
[Docs/Tutorial 6]: Configure Apollo VSCode

### DIFF
--- a/docs/source/tutorial/client.mdx
+++ b/docs/source/tutorial/client.mdx
@@ -40,7 +40,7 @@ APOLLO_KEY=service:<your-service-name>:<hash-from-apollo-engine>
 The entry should basically look something like this:
 
 ```bash:title=.env
-APOLLO_KEY=service:my-service-439:E4VSTiXeFWaSSBgFWXOiSA
+APOLLO_KEY=service:<your-service-name>:E4VSTiXeFWaSSBgFWXOiSA
 ```
 
 Our key is now stored under the environment variable `APOLLO_KEY`. Apollo VSCode uses this API key to pull down your schema from the registry.
@@ -50,11 +50,11 @@ Next, create an Apollo config file called `apollo.config.js`. This config file i
 ```js:title=apollo.config.js
 module.exports = {
   client: {
-    name: 'Space Explorer [web]',
-    service: 'space-explorer',
+    service: '<your-service-name>',
   },
 };
 ```
+> Note: You might need to reload your VSCode window in case you get an error on Loading Schema.
 
 Great, we're all set up! Let's dive into building our first client.
 


### PR DESCRIPTION
Aligns the client service `id` / `name` placeholder because it was a bit misleading. Adds a new Note in case you receive an error on Loading Schema. This happened to me, I guess due to I installed the plugin before configuring the service in `apollo.config.js`.