### PR TITLE
docs: updated the tutorial documents for @apollo/client@3.0.0

### DIFF
--- a/docs/source/tutorial/client.mdx
+++ b/docs/source/tutorial/client.mdx
@@ -72,19 +72,15 @@ Navigate to `src/index.tsx` so we can create our client. The `uri` that we pass 
 ```tsx:title=src/index.tsx
 import { 
   ApolloClient,
-  HttpLink,
   InMemoryCache,
   NormalizedCacheObject,
 } from '@apollo/client';
 
 const cache = new InMemoryCache();
-const link = new HttpLink({
-  uri: 'http://localhost:4000/'
-});
 
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
   cache,
-  link
+  uri: 'http://localhost:4000/'
 });
 ```
 
@@ -155,6 +151,7 @@ import {
   ApolloClient,
   ApolloProvider,
   gql,
+  InMemoryCache,
   NormalizedCacheObject,
   useQuery,
 } from '@apollo/client';
@@ -162,10 +159,9 @@ import {
 import Pages from './pages';
 import Login from './pages/login';
 import injectStyles from './styles';
-import { cache } from './cache';
-
+  
 // previous variable declarations
-
+  
 injectStyles();
 ReactDOM.render(
   <ApolloProvider client={client}>

--- a/docs/source/tutorial/client.mdx
+++ b/docs/source/tutorial/client.mdx
@@ -142,7 +142,7 @@ Go ahead and delete the `client.query()` call you just made and the `gql` import
 
 Connecting Apollo Client to our React app with Apollo's hooks allows us to easily bind GraphQL operations to our UI.
 
-To connect Apollo Client to React, we will wrap our app in the `ApolloProvider` component exported from the `@apollo/react-hooks` package and pass our client to the `client` prop. The `ApolloProvider` component is similar to React’s context provider. It wraps your React app and places the client on the context, which allows you to access it from anywhere in your component tree.
+To connect Apollo Client to React, we will wrap our app in the `ApolloProvider` component exported from the `@apollo/client` package and pass our client to the `client` prop. The `ApolloProvider` component is similar to React’s context provider. It wraps your React app and places the client on the context, which allows you to access it from anywhere in your component tree.
 
 Open `src/index.tsx` and add the following lines of code:
 

--- a/docs/source/tutorial/client.mdx
+++ b/docs/source/tutorial/client.mdx
@@ -70,9 +70,12 @@ Navigate to `src/index.tsx` so we can create our client. The `uri` that we pass 
 <MultiCodeBlock>
 
 ```tsx:title=src/index.tsx
-import { ApolloClient } from 'apollo-client';
-import { InMemoryCache, NormalizedCacheObject } from 'apollo-cache-inmemory';
-import { HttpLink } from 'apollo-link-http';
+import { 
+  ApolloClient,
+  HttpLink,
+  InMemoryCache,
+  NormalizedCacheObject,
+} from '@apollo/client';
 
 const cache = new InMemoryCache();
 const link = new HttpLink({
@@ -100,7 +103,7 @@ With a `client.query()` call, we can query our graph's API. Add the following li
 <MultiCodeBlock>
 
 ```tsx:title=src/index.tsx
-import gql from 'graphql-tag'; // highlight-line
+import { gql } from '@apollo/client'; // highlight-line
 ```
 
 </MultiCodeBlock>
@@ -146,14 +149,20 @@ Open `src/index.tsx` and add the following lines of code:
 <MultiCodeBlock>
 
 ```tsx{4-8,12-18}:title=src/index.tsx
-import { ApolloClient } from 'apollo-client'; // preserve-line
-import { InMemoryCache, NormalizedCacheObject } from 'apollo-cache-inmemory'; // preserve-line
-import { HttpLink } from 'apollo-link-http'; // preserve-line
-import { ApolloProvider } from '@apollo/react-hooks';
 import React from 'react';
-import ReactDOM from 'react-dom'; 
+import ReactDOM from 'react-dom';
+import {
+  ApolloClient,
+  ApolloProvider,
+  gql,
+  NormalizedCacheObject,
+  useQuery,
+} from '@apollo/client';
+
 import Pages from './pages';
+import Login from './pages/login';
 import injectStyles from './styles';
+import { cache } from './cache';
 
 // previous variable declarations
 

--- a/docs/source/tutorial/local-state.mdx
+++ b/docs/source/tutorial/local-state.mdx
@@ -25,11 +25,13 @@ Navigate to `src/resolvers.tsx` and copy the following code to create your clien
 <MultiCodeBlock>
 
 ```tsx:title=src/resolvers.tsx
-import gql from 'graphql-tag';
-import { ApolloCache } from 'apollo-cache';
+import {
+  ApolloCache,
+  gql,
+  Resolvers,
+} from '@apollo/client';
 import * as GetCartItemTypes from './pages/__generated__/GetCartItems';
 import * as LaunchTileTypes from './pages/__generated__/LaunchTile';
-import { Resolvers } from 'apollo-client'
 
 export const typeDefs = gql`
   extend type Query {
@@ -113,8 +115,11 @@ Let's look at an example where we query the `isLoggedIn` field we wrote to the c
 <MultiCodeBlock>
 
 ```tsx{8-12,15}:title=src/index.tsx
-import { ApolloProvider, useQuery } from '@apollo/react-hooks';  // preserve-line
-import gql from 'graphql-tag'; // preserve-line
+import {
+  ApolloProvider,
+  gql,
+  useQuery,
+} from '@apollo/client'; // preserve-line
 
 import Pages from './pages'; // preserve-line
 import Login from './pages/login'; // preserve-line
@@ -150,8 +155,7 @@ Let's look at another example of a component that queries local state in `src/pa
 
 ```tsx:title=src/pages/cart.tsx
 import React, { Fragment } from 'react'; // preserve-line
-import { useQuery } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag';
+import { gql, useQuery } from '@apollo/client'; // preserve-line
 
 import { Header, Loading } from '../components'; // preserve-line
 import { CartItem, BookTrips } from '../containers'; // preserve-line
@@ -215,7 +219,7 @@ To add a virtual field, first extend the type of the data you're adding the fiel
 <MultiCodeBlock>
 
 ```ts:title=src/resolvers.tsx
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 export const schema = gql`
   extend type Launch {
@@ -294,7 +298,7 @@ Direct cache writes are convenient when you want to write a simple field, like a
 ```tsx:title=src/containers/logout-button.tsx
 import React from 'react';
 import styled from 'react-emotion';
-import { useApolloClient } from '@apollo/react-hooks';
+import { useApolloClient } from '@apollo/client';
 
 import { menuItemClassName } from '../components/menu-item';
 import { ReactComponent as ExitIcon } from '../assets/icons/exit.svg';
@@ -333,8 +337,7 @@ We can also perform direct writes within the `update` function of the `useMutati
 
 ```tsx{39-41}:title=src/containers/book-trips.tsx
 import React from 'react'; // preserve-line
-import { useMutation } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag';
+import { gql, useMutation } from '@apollo/client'; // preserve-line
 
 import Button from '../components/button'; // preserve-line
 import { GET_LAUNCH } from './cart-item'; // preserve-line
@@ -392,8 +395,7 @@ export default BookTrips;
 
 ```jsx:title=src/containers/book-trips.jsx
 import React from 'react'; // preserve-line
-import { useMutation } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag';
+import { gql, useMutation } from '@apollo/client'; // preserve-line
 
 import Button from '../components/button'; // preserve-line
 import { GET_LAUNCH } from './cart-item'; // preserve-line
@@ -499,7 +501,7 @@ Let's see how we call the `addOrRemoveFromCart` mutation in a component:
 <MultiCodeBlock>
 
 ```tsx:title=src/containers/action-button.tsx
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 const TOGGLE_CART = gql`
   mutation addOrRemoveFromCart($launchId: ID!) {
@@ -518,8 +520,7 @@ Now that our local mutation is complete, let's build out the rest of the `Action
 
 ```tsx:title=src/containers/action-button.tsx
 import React from 'react';
-import { useMutation } from '@apollo/react-hooks';
-import gql from 'graphql-tag';
+import { gql, useMutation } from '@apollo/client';
 
 import { GET_LAUNCH_DETAILS } from '../pages/launch';
 import Button from '../components/button';

--- a/docs/source/tutorial/local-state.mdx
+++ b/docs/source/tutorial/local-state.mdx
@@ -84,21 +84,14 @@ import { resolvers, typeDefs } from './resolvers';
 
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
   cache,
-  link: new HttpLink({
-    uri: 'http://localhost:4000/graphql',
-    headers: {
-      authorization: localStorage.getItem('token'),
-    },
-  }),
+  uri: 'http://localhost:4000/graphql',
+  headers: {
+    authorization: localStorage.getItem('token') || '',
+    'client-name': 'Space Explorer [web]',
+    'client-version': '1.0.0',
+  },
   typeDefs,
   resolvers,
-});
-
-cache.writeData({
-  data: {
-    isLoggedIn: !!localStorage.getItem('token'),
-    cartItems: [],
-  },
 });
 ```
 
@@ -116,15 +109,20 @@ Let's look at an example where we query the `isLoggedIn` field we wrote to the c
 
 ```tsx{8-12,15}:title=src/index.tsx
 import {
+  ApolloClient,
   ApolloProvider,
   gql,
+  InMemoryCache,
+  NormalizedCacheObject,
   useQuery,
 } from '@apollo/client'; // preserve-line
 
 import Pages from './pages'; // preserve-line
 import Login from './pages/login'; // preserve-line
 import injectStyles from './styles'; // preserve-line
-
+  
+// previous variable declarations  
+  
 const IS_LOGGED_IN = gql`
   query IsUserLoggedIn {
     isLoggedIn @client

--- a/docs/source/tutorial/mutations.mdx
+++ b/docs/source/tutorial/mutations.mdx
@@ -26,11 +26,14 @@ The first step is defining our GraphQL mutation. To start, navigate to `src/page
 
 ```tsx:title=src/pages/login.tsx
 import React from 'react'; // preserve-line
-import { useApolloClient, useMutation } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag';
+import { 
+  ApolloClient,
+  gql,
+  useApolloClient,
+  useMutation,
+} from '@apollo/client';  // preserve-line
 
 import { LoginForm, Loading } from '../components'; // preserve-line
-import ApolloClient from 'apollo-client'; // preserve-line
 import * as LoginTypes from './__generated__/login';
 
 export const LOGIN_USER = gql`

--- a/docs/source/tutorial/mutations.mdx
+++ b/docs/source/tutorial/mutations.mdx
@@ -112,13 +112,6 @@ const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
     }, 
   }),
 });
-
-cache.writeData({
-  data: {
-    isLoggedIn: !!localStorage.getItem('token'),
-    cartItems: [],
-  },
-});
 ```
 
 
@@ -129,13 +122,6 @@ const client = new ApolloClient({
     headers: { authorization: localStorage.getItem('token') },
     uri: "http://localhost:4000/graphql",
   }),
-});
-
-cache.writeData({
-  data: {
-    isLoggedIn: !!localStorage.getItem('token'),
-    cartItems: [],
-  },
 });
 ```
 

--- a/docs/source/tutorial/mutations.mdx
+++ b/docs/source/tutorial/mutations.mdx
@@ -105,12 +105,12 @@ We're almost done completing our login feature! Before we do, we need to attach 
 ```tsx{5-7}:title=src/index.tsx
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
   cache,
-  link: new HttpLink({
-    uri: 'http://localhost:4000/graphql',
-    headers: {
-      authorization: localStorage.getItem('token'),
-    }, 
-  }),
+  uri: 'http://localhost:4000/graphql',
+  headers: {
+    authorization: localStorage.getItem('token') || '',
+    'client-name': 'Space Explorer [web]',
+    'client-version': '1.0.0',
+  },
 });
 ```
 
@@ -118,10 +118,12 @@ const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
 ```jsx{4}:title=src/index.jsx
 const client = new ApolloClient({
   cache,
-  link: new HttpLink({
-    headers: { authorization: localStorage.getItem('token') },
-    uri: "http://localhost:4000/graphql",
-  }),
+  uri: 'http://localhost:4000/graphql',
+  headers: {
+    authorization: localStorage.getItem('token') || '',
+    'client-name': 'Space Explorer [web]',
+    'client-version': '1.0.0',
+  },
 });
 ```
 

--- a/docs/source/tutorial/mutations.mdx
+++ b/docs/source/tutorial/mutations.mdx
@@ -14,7 +14,7 @@ With Apollo Client, updating data from a graph API is as simple as calling a fun
 
 The `useMutation` hook is another important building block in an Apollo app. It leverages React's [Hooks API](https://reactjs.org/docs/hooks-intro.html) to provide a function to execute a GraphQL mutation. Additionally, it tracks the loading, completion, and error state of that mutation.
 
-Updating data with a `useMutation` hook from `@apollo/react-hooks` is very similar to fetching data with a `useQuery` hook. The main difference is that the first value in the `useMutation` result tuple is a **mutate function** that actually triggers the mutation when it is called. The second value in the result tuple is a result object that contains loading and error state, as well as the return value from the mutation. Let's see an example:
+Updating data with a `useMutation` hook from `@apollo/client` is very similar to fetching data with a `useQuery` hook. The main difference is that the first value in the `useMutation` result tuple is a **mutate function** that actually triggers the mutation when it is called. The second value in the result tuple is a result object that contains loading and error state, as well as the return value from the mutation. Let's see an example:
 
 ## Update data with useMutation
 

--- a/docs/source/tutorial/queries.mdx
+++ b/docs/source/tutorial/queries.mdx
@@ -8,7 +8,7 @@ import Disclaimer from '../../shared/disclaimer.mdx';
 
 Time to accomplish: _15 Minutes_
 
-Apollo Client simplifies fetching data from a graph API because it intelligently caches your data, as well as tracks loading and error state. In the previous section, we learned how to fetch a sample query with Apollo Client without using a view integration. In this section, we'll learn how to use the `useQuery` hook from `@apollo/react-hooks` to fetch more complex queries and execute features like pagination.
+Apollo Client simplifies fetching data from a graph API because it intelligently caches your data, as well as tracks loading and error state. In the previous section, we learned how to fetch a sample query with Apollo Client without using a view integration. In this section, we'll learn how to use the `useQuery` hook from `@apollo/client` to fetch more complex queries and execute features like pagination.
 
 ## The useQuery hook
 
@@ -20,7 +20,7 @@ The `useQuery` hook leverages React's [Hooks API](https://reactjs.org/docs/hooks
 
 <Disclaimer />
 
-To create a component with `useQuery`, import `useQuery` from `@apollo/react-hooks`, pass your query wrapped with `gql` in as the first parameter, then wire your component up to use the `loading`, `data`, and `error` properties on the result object to render UI in your app.
+To create a component with `useQuery`, import `useQuery` from `@apollo/client`, pass your query wrapped with `gql` in as the first parameter, then wire your component up to use the `loading`, `data`, and `error` properties on the result object to render UI in your app.
 
 First, we're going to build a GraphQL query that fetches a list of launches. We're also going to import some components that we will need in the next step. Navigate to `src/pages/launches.tsx` to get started and copy the code below into the file.
 

--- a/docs/source/tutorial/queries.mdx
+++ b/docs/source/tutorial/queries.mdx
@@ -28,8 +28,7 @@ First, we're going to build a GraphQL query that fetches a list of launches. We'
 
 ```tsx:title=src/pages/launches.tsx
 import React, { Fragment } from 'react'; // preserve-line
-import { useQuery } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag';
+import { gql, useQuery } from '@apollo/client';  // preserve-line
 
 import { LaunchTile, Header, Button, Loading } from '../components'; // preserve-line
 import { RouteComponentProps } from '@reach/router';
@@ -214,8 +213,7 @@ Let's navigate to `src/pages/launch.tsx` to build out our detail page. First, we
 
 ```tsx:title=src/pages/launch.tsx
 import React, { Fragment } from 'react'; // preserve-line
-import { useQuery } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag'; 
+import { gql, useQuery } from '@apollo/client';  // preserve-line
 
 import { Loading, Header, LaunchDetail } from '../components'; // preserve-line
 import { ActionButton } from '../containers'; // preserve-line
@@ -372,8 +370,7 @@ First, let's navigate to `src/pages/profile.tsx` and write our query:
 
 ```tsx:title=src/pages/profile.tsx
 import React, { Fragment } from 'react'; // preserve-line
-import { useQuery } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag'; // preserve-line
+import { gql, useQuery } from '@apollo/client';  // preserve-line
 
 import { Loading, Header, LaunchTile } from '../components'; // preserve-line
 import { LAUNCH_TILE_DATA } from './launches'; // preserve-line


### PR DESCRIPTION
Hi, there.

# Summary
As you know, [Apollo Client v3.0.0](https://github.com/apollographql/apollo-client/releases/tag/v3.0.0) has been released, then things can be imported from `@apollo/client`.
Speaking of which, we have to update documents for the tutorial.
So, now I create a pull request.

# Details
I just modified parts of the import statement in the documents.
I cared about the alphabetical order and comma.

Please let me know if there is a typo or something I have to fix.

Thanks :D