### PR TITLE
Add subfields to LoginUser mutation to avoid error

### DIFF
--- a/docs/source/tutorial/mutation-resolvers.md
+++ b/docs/source/tutorial/mutation-resolvers.md
@@ -124,17 +124,29 @@ GraphQL mutations are structured exactly like queries, except they use the `muta
 
 ```graphql
 mutation LoginUser {
-  login(email: "daisy@apollographql.com")
+  login(email: "daisy@apollographql.com") {
+    email
+    token
+  }
 }
 ```
 
-The server should respond with a string that looks like this: 
+The server will respond like this: 
 
+```
+  "data": {
+    "login": {
+      "email": "daisy@apollographql.com",
+      "token": "ZGFpc3lAYXBvbGxvZ3JhcGhxbC5jb20="
+      }               
+     }
+```
+
+The string below is your login token (which is just the Base64 encoding of the email address you provided). Copy it to use in the next mutation.
 ```
 ZGFpc3lAYXBvbGxvZ3JhcGhxbC5jb20=
 ```
 
-This is your login token (which is just the Base64 encoding of the email address you provided). Copy it to use in the next mutation.
 
 ### Book trips
 


### PR DESCRIPTION
This mutation query without a subfield results in the following error:     

"errors": [
      {
        "message": "Field \"login\" of type \"User!\" must have a selection of subfields. Did you mean \"login { ... }\"?"

In order to prevent this error, I added two subfields. I maintain use of the original token string and made minor edits to then isolate the token string from the mutation output and continue with the original flow of the tutorial.