### PR TITLE
[GM-1392] Recommend schema check configurations over CLI flags 

### DIFF
--- a/studio-docs/source/schema-checks.mdx
+++ b/studio-docs/source/schema-checks.mdx
@@ -160,9 +160,9 @@ If you want to check your schema against multiple variants, call `apollo service
 
 ![multiple service checks](./img/schema-checks/multi-github-check.png)
 
-## Customizing checks
+## Customizing checks with CLI flags
 
-> This section describes customizing a single call to `apollo service:check`. To customize default behavior for _all_ of a graph's schema checks, see [Configuring schema checks](./check-configurations).
+> **Important Note:** This section describes customizing a single call to `apollo service:check` using CLI flags; however, **we highly recommend** [configuring schema checks](./check-configurations) with Apollo Studio to customize default behavior for _all_ of a graph's schema checks.
 
 You can customize which operations schema checks will check against to classify schema changes as breaking or non-breaking.
 


### PR DESCRIPTION
As it is right now, it sounds like we recommend using CLI flags to customize validation. But we should instead make it clear that we recommend controlling this centrally in Apollo Studio with Check Configurations.