### PR TITLE
Initial AC3 updates

### DIFF
--- a/docs/source/tutorial/client.mdx
+++ b/docs/source/tutorial/client.mdx
@@ -20,11 +20,9 @@ For this half of the tutorial, we will be working in the `client/` folder of the
 cd start/client && npm install
 ```
 
-Now, our dependencies are installed. Here are the packages we will be using to build out our frontend:
+Now, our dependencies are installed. Here are the main packages we will be using to build out our frontend:
 
-- `apollo-client`: A complete data management solution with an intelligent cache. In this tutorial, we will be using the Apollo Client 3.0 preview since it includes local state management capabilities and sets your cache up for you.
-- `react-apollo`: The view layer integration for React that exports components such as `Query` and `Mutation`
-- `graphql-tag`: The tag function `gql` that we use to wrap our query strings in order to parse them into an AST
+- `@apollo/client`: A complete data management solution with an intelligent cache.
 
 ### Configure Apollo VSCode
 
@@ -61,7 +59,7 @@ Great, we're all set up! Let's dive into building our first client.
 
 ## Create an Apollo Client
 
-<Disclaimer /> 
+<Disclaimer />
 
 Now that we have installed the necessary packages, let's create an `ApolloClient` instance.
 
@@ -70,18 +68,15 @@ Navigate to `src/index.tsx` so we can create our client. The `uri` that we pass 
 <MultiCodeBlock>
 
 ```tsx:title=src/index.tsx
-import { ApolloClient } from 'apollo-client';
-import { InMemoryCache, NormalizedCacheObject } from 'apollo-cache-inmemory';
-import { HttpLink } from 'apollo-link-http';
-
-const cache = new InMemoryCache();
-const link = new HttpLink({
-  uri: 'http://localhost:4000/'
-});
+import {
+  ApolloClient,
+  InMemoryCache,
+  NormalizedCacheObject
+} from '@apollo/client';
 
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
-  cache,
-  link
+  uri: 'http://localhost:4000/',
+  cache: new InMemoryCache()
 });
 ```
 
@@ -94,13 +89,13 @@ In just a few lines of code, our client is ready to fetch data! Let's try making
 
 Before we show you how to use the React integration for Apollo, let's send a query with vanilla JavaScript.
 
-With a `client.query()` call, we can query our graph's API. Add the following line of code to your imports in `src/index.tsx`.
+With a `client.query()` call, we can query our graph's API. Adjust your `@apollo/client` import to include `gql` in `src/index.tsx`.
 
 
 <MultiCodeBlock>
 
 ```tsx:title=src/index.tsx
-import gql from 'graphql-tag'; // highlight-line
+import { gql, ApolloClient, InMemoryCache } from '@apollo/client'; // highlight-line
 ```
 
 </MultiCodeBlock>
@@ -139,19 +134,21 @@ Go ahead and delete the `client.query()` call you just made and the `gql` import
 
 Connecting Apollo Client to our React app with Apollo's hooks allows us to easily bind GraphQL operations to our UI.
 
-To connect Apollo Client to React, we will wrap our app in the `ApolloProvider` component exported from the `@apollo/react-hooks` package and pass our client to the `client` prop. The `ApolloProvider` component is similar to React’s context provider. It wraps your React app and places the client on the context, which allows you to access it from anywhere in your component tree.
+To connect Apollo Client to React, we will wrap our app in the `ApolloProvider` component exported from the `@apollo/client` package and pass our client to the `client` prop. The `ApolloProvider` component is similar to React’s context provider. It wraps your React app and places the client on the context, which allows you to access it from anywhere in your component tree.
 
 Open `src/index.tsx` and add the following lines of code:
 
 <MultiCodeBlock>
 
-```tsx{4-8,12-18}:title=src/index.tsx
-import { ApolloClient } from 'apollo-client'; // preserve-line
-import { InMemoryCache, NormalizedCacheObject } from 'apollo-cache-inmemory'; // preserve-line
-import { HttpLink } from 'apollo-link-http'; // preserve-line
-import { ApolloProvider } from '@apollo/react-hooks';
+```tsx:title=src/index.tsx
+import {
+  ApolloClient,
+  InMemoryCache,
+  NormalizedCacheObject,
+  ApolloProvider
+} from '@apollo/client';
 import React from 'react';
-import ReactDOM from 'react-dom'; 
+import ReactDOM from 'react-dom';
 import Pages from './pages';
 import injectStyles from './styles';
 
@@ -161,7 +158,7 @@ injectStyles();
 ReactDOM.render(
   <ApolloProvider client={client}>
     <Pages />
-  </ApolloProvider>, 
+  </ApolloProvider>,
   document.getElementById('root')
 );
 ```

--- a/docs/source/tutorial/client.mdx
+++ b/docs/source/tutorial/client.mdx
@@ -20,9 +20,7 @@ For this half of the tutorial, we will be working in the `client/` folder of the
 cd start/client && npm install
 ```
 
-Now, our dependencies are installed. Here are the main packages we will be using to build out our frontend:
-
-- `@apollo/client`: A complete data management solution with an intelligent cache.
+Along with other dependencies, this installs the `@apollo/client` package, which includes all of the Apollo Client features we'll use.
 
 ### Configure Apollo VSCode
 
@@ -89,7 +87,7 @@ In just a few lines of code, our client is ready to fetch data! Let's try making
 
 Before we show you how to use the React integration for Apollo, let's send a query with vanilla JavaScript.
 
-With a `client.query()` call, we can query our graph's API. Adjust your `@apollo/client` import to include `gql` in `src/index.tsx`.
+With a `client.query()` call, we can query our graph's API. Adjust your `@apollo/client` import to include `gql` in `src/index.tsx`:
 
 
 <MultiCodeBlock>

--- a/docs/source/tutorial/local-state.mdx
+++ b/docs/source/tutorial/local-state.mdx
@@ -25,11 +25,9 @@ Navigate to `src/resolvers.tsx` and copy the following code to create your clien
 <MultiCodeBlock>
 
 ```tsx:title=src/resolvers.tsx
-import gql from 'graphql-tag';
-import { ApolloCache } from 'apollo-cache';
+import { gql, ApolloCache, Resolvers } from '@apollo/client';
 import * as GetCartItemTypes from './pages/__generated__/GetCartItems';
 import * as LaunchTileTypes from './pages/__generated__/LaunchTile';
-import { Resolvers } from 'apollo-client'
 
 export const typeDefs = gql`
   extend type Query {
@@ -47,8 +45,8 @@ export const typeDefs = gql`
 `;
 
 type ResolverFn = (
-  parent: any, 
-  args: any, 
+  parent: any,
+  args: any,
   { cache } : { cache: ApolloCache<any> }
 ) => any;
 
@@ -113,8 +111,7 @@ Let's look at an example where we query the `isLoggedIn` field we wrote to the c
 <MultiCodeBlock>
 
 ```tsx{8-12,15}:title=src/index.tsx
-import { ApolloProvider, useQuery } from '@apollo/react-hooks';  // preserve-line
-import gql from 'graphql-tag'; // preserve-line
+import { gql, ApolloProvider, useQuery } from '@apollo/client';  // preserve-line
 
 import Pages from './pages'; // preserve-line
 import Login from './pages/login'; // preserve-line
@@ -150,8 +147,7 @@ Let's look at another example of a component that queries local state in `src/pa
 
 ```tsx:title=src/pages/cart.tsx
 import React, { Fragment } from 'react'; // preserve-line
-import { useQuery } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag';
+import { gql, useQuery } from '@apollo/client'; // preserve-line
 
 import { Header, Loading } from '../components'; // preserve-line
 import { CartItem, BookTrips } from '../containers'; // preserve-line
@@ -178,7 +174,7 @@ const Cart: React.FC<CartProps> = () => {
   const { data, loading, error } = useQuery<
     GetCartItemsTypes.GetCartItems
   >(GET_CART_ITEMS);
-  
+
   if (loading) return <Loading />;
   if (error) return <p>ERROR: {error.message}</p>;
 
@@ -215,7 +211,7 @@ To add a virtual field, first extend the type of the data you're adding the fiel
 <MultiCodeBlock>
 
 ```ts:title=src/resolvers.tsx
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 export const schema = gql`
   extend type Launch {
@@ -226,7 +222,7 @@ export const schema = gql`
 
 </MultiCodeBlock>
 
-Next, specify a client resolver on the `Launch` type to tell Apollo Client how to resolve your virtual field :
+Next, specify a client resolver on the `Launch` type to tell Apollo Client how to resolve your virtual field:
 
 <MultiCodeBlock>
 
@@ -243,12 +239,12 @@ interface AppResolvers extends Resolvers {
 export const resolvers: AppResolvers = { // highlight-line
   Launch: {
     isInCart: (launch: LaunchTileTypes.LaunchTile, _, { cache }): boolean => {
-      const queryResult = cache.readQuery<GetCartItemTypes.GetCartItems>({ 
-        query: GET_CART_ITEMS 
+      const queryResult = cache.readQuery<GetCartItemTypes.GetCartItems>({
+        query: GET_CART_ITEMS
       });
       if (queryResult) {
         return queryResult.cartItems.includes(launch.id)
-      } 
+      }
       return false;
     }
   },
@@ -294,7 +290,7 @@ Direct cache writes are convenient when you want to write a simple field, like a
 ```tsx:title=src/containers/logout-button.tsx
 import React from 'react';
 import styled from 'react-emotion';
-import { useApolloClient } from '@apollo/react-hooks';
+import { useApolloClient } from '@apollo/client';
 
 import { menuItemClassName } from '../components/menu-item';
 import { ReactComponent as ExitIcon } from '../assets/icons/exit.svg';
@@ -331,10 +327,9 @@ We can also perform direct writes within the `update` function of the `useMutati
 
 <!-- TODO: make this more brief after a fix lands -->
 
-```tsx{39-41}:title=src/containers/book-trips.tsx
+```tsx{38-40}:title=src/containers/book-trips.tsx
 import React from 'react'; // preserve-line
-import { useMutation } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag';
+import { gql, useMutation } from '@apollo/client'; // preserve-line
 
 import Button from '../components/button'; // preserve-line
 import { GET_LAUNCH } from './cart-item'; // preserve-line
@@ -360,7 +355,7 @@ const BookTrips: React.FC<BookTripsProps> = ({ cartItems }) => {
   const [
     bookTrips, { data }
   ] = useMutation<
-    BookTripsTypes.BookTrips, 
+    BookTripsTypes.BookTrips,
     BookTripsTypes.BookTripsVariables
   > (
     BOOK_TRIPS,
@@ -379,8 +374,8 @@ const BookTrips: React.FC<BookTripsProps> = ({ cartItems }) => {
   return data && data.bookTrips && !data.bookTrips.success
     ? <p data-testid="message">{data.bookTrips.message}</p>
     : (
-      <Button 
-        onClick={() => bookTrips()} 
+      <Button
+        onClick={() => bookTrips()}
         data-testid="book-button">
         Book All
       </Button>
@@ -392,8 +387,7 @@ export default BookTrips;
 
 ```jsx:title=src/containers/book-trips.jsx
 import React from 'react'; // preserve-line
-import { useMutation } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag';
+import { gql, useMutation } from '@apollo/client'; // preserve-line
 
 import Button from '../components/button'; // preserve-line
 import { GET_LAUNCH } from './cart-item'; // preserve-line
@@ -419,7 +413,7 @@ const BookTrips: React.FC<BookTripsProps> = ({ cartItems }) => {
   const [
     bookTrips, { data }
   ] = useMutation<
-    BookTripsTypes.BookTrips, 
+    BookTripsTypes.BookTrips,
     BookTripsTypes.BookTripsVariables
   > (
     BOOK_TRIPS,
@@ -438,8 +432,8 @@ const BookTrips: React.FC<BookTripsProps> = ({ cartItems }) => {
   return data && data.bookTrips && !data.bookTrips.success
     ? <p data-testid="message">{data.bookTrips.message}</p>
     : (
-      <Button 
-        onClick={() => bookTrips()} 
+      <Button
+        onClick={() => bookTrips()}
         data-testid="book-button">
         Book All
       </Button>
@@ -471,8 +465,8 @@ export const resolvers = {
   Mutation: {
     addOrRemoveFromCart: (_, { id }: { id: string }, { cache }): string[] => {
       const queryResult = cache
-        .readQuery<GetCartItemTypes.GetCartItems, any>({ 
-          query: GET_CART_ITEMS 
+        .readQuery<GetCartItemTypes.GetCartItems, any>({
+          query: GET_CART_ITEMS
         });
       if (queryResult) {
         const { cartItems } = queryResult;
@@ -499,7 +493,7 @@ Let's see how we call the `addOrRemoveFromCart` mutation in a component:
 <MultiCodeBlock>
 
 ```tsx:title=src/containers/action-button.tsx
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 const TOGGLE_CART = gql`
   mutation addOrRemoveFromCart($launchId: ID!) {
@@ -518,8 +512,7 @@ Now that our local mutation is complete, let's build out the rest of the `Action
 
 ```tsx:title=src/containers/action-button.tsx
 import React from 'react';
-import { useMutation } from '@apollo/react-hooks';
-import gql from 'graphql-tag';
+import { gql, useMutation } from '@apollo/client';
 
 import { GET_LAUNCH_DETAILS } from '../pages/launch';
 import Button from '../components/button';

--- a/docs/source/tutorial/mutations.mdx
+++ b/docs/source/tutorial/mutations.mdx
@@ -14,7 +14,7 @@ With Apollo Client, updating data from a graph API is as simple as calling a fun
 
 The `useMutation` hook is another important building block in an Apollo app. It leverages React's [Hooks API](https://reactjs.org/docs/hooks-intro.html) to provide a function to execute a GraphQL mutation. Additionally, it tracks the loading, completion, and error state of that mutation.
 
-Updating data with a `useMutation` hook from `@apollo/react-hooks` is very similar to fetching data with a `useQuery` hook. The main difference is that the first value in the `useMutation` result tuple is a **mutate function** that actually triggers the mutation when it is called. The second value in the result tuple is a result object that contains loading and error state, as well as the return value from the mutation. Let's see an example:
+Updating data with a `useMutation` hook from `@apollo/client` is very similar to fetching data with a `useQuery` hook. The main difference is that the first value in the `useMutation` result tuple is a **mutate function** that actually triggers the mutation when it is called. The second value in the result tuple is a result object that contains loading and error state, as well as the return value from the mutation. Let's see an example:
 
 ## Update data with useMutation
 
@@ -26,11 +26,9 @@ The first step is defining our GraphQL mutation. To start, navigate to `src/page
 
 ```tsx:title=src/pages/login.tsx
 import React from 'react'; // preserve-line
-import { useApolloClient, useMutation } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag';
+import { gql, ApolloClient, useApolloClient, useMutation } from '@apollo/client'; // preserve-line
 
 import { LoginForm, Loading } from '../components'; // preserve-line
-import ApolloClient from 'apollo-client'; // preserve-line
 import * as LoginTypes from './__generated__/login';
 
 export const LOGIN_USER = gql`
@@ -61,7 +59,7 @@ To create a better experience for our users, we want to persist the login betwee
 
 ### Expose Apollo Client with useApolloClient
 
-One of the main functions of React Apollo is that it puts your `ApolloClient` instance on React's context. Sometimes, we need to access the `ApolloClient` instance to directly call a method that isn't exposed by the `@apollo/react-hooks` helper components. The `useApolloClient` hook can help us access the client.
+Apollo Client ensures that your `ApolloClient` instance is available through React's context. Sometimes, we need to access the `ApolloClient` instance to directly call a method that isn't exposed by the `@apollo/client` helper components. The `useApolloClient` hook can help us access the client.
 
 Let's call `useApolloClient` to get the currently configured client instance. Next, we want to pass an `onCompleted` callback to `useMutation` that will be called once the mutation is complete with its return value. This callback is where we will save the login token to `localStorage`.
 
@@ -106,7 +104,7 @@ const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
     uri: 'http://localhost:4000/graphql',
     headers: {
       authorization: localStorage.getItem('token'),
-    }, 
+    },
   }),
 });
 

--- a/docs/source/tutorial/queries.mdx
+++ b/docs/source/tutorial/queries.mdx
@@ -8,7 +8,7 @@ import Disclaimer from '../../shared/disclaimer.mdx';
 
 Time to accomplish: _15 Minutes_
 
-Apollo Client simplifies fetching data from a graph API because it intelligently caches your data, as well as tracks loading and error state. In the previous section, we learned how to fetch a sample query with Apollo Client without using a view integration. In this section, we'll learn how to use the `useQuery` hook from `@apollo/react-hooks` to fetch more complex queries and execute features like pagination.
+Apollo Client simplifies fetching data from a graph API because it intelligently caches your data, as well as tracks loading and error state. In the previous section, we learned how to fetch a sample query with Apollo Client without using a view integration. In this section, we'll learn how to use the `useQuery` hook from `@apollo/client` to fetch more complex queries and execute features like pagination.
 
 ## The useQuery hook
 
@@ -20,7 +20,7 @@ The `useQuery` hook leverages React's [Hooks API](https://reactjs.org/docs/hooks
 
 <Disclaimer />
 
-To create a component with `useQuery`, import `useQuery` from `@apollo/react-hooks`, pass your query wrapped with `gql` in as the first parameter, then wire your component up to use the `loading`, `data`, and `error` properties on the result object to render UI in your app.
+To create a component with `useQuery`, import `useQuery` from `@apollo/client`, pass your query wrapped with `gql` in as the first parameter, then wire your component up to use the `loading`, `data`, and `error` properties on the result object to render UI in your app.
 
 First, we're going to build a GraphQL query that fetches a list of launches. We're also going to import some components that we will need in the next step. Navigate to `src/pages/launches.tsx` to get started and copy the code below into the file.
 
@@ -28,8 +28,7 @@ First, we're going to build a GraphQL query that fetches a list of launches. We'
 
 ```tsx:title=src/pages/launches.tsx
 import React, { Fragment } from 'react'; // preserve-line
-import { useQuery } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag';
+import { gql, useQuery } from '@apollo/client'; // preserve-line
 
 import { LaunchTile, Header, Button, Loading } from '../components'; // preserve-line
 import { RouteComponentProps } from '@reach/router';
@@ -69,12 +68,12 @@ Now, let's pass that query to Apollo's `useQuery` component to render the list. 
 interface LaunchesProps extends RouteComponentProps {}
 
 const Launches: React.FC<LaunchesProps> = () => {
-  const { 
-    data, 
-    loading, 
+  const {
+    data,
+    loading,
     error
   } = useQuery<
-    GetLaunchListTypes.GetLaunchList, 
+    GetLaunchListTypes.GetLaunchList,
     GetLaunchListTypes.GetLaunchListVariables
   >(GET_LAUNCHES);
 
@@ -113,13 +112,13 @@ To build a paginated list with Apollo, we first need to destructure the `fetchMo
 
 ```tsx:title=src/pages/launches.tsx
 const Launches: React.FC<LaunchesProps> = () => {
-  const { 
-    data, 
-    loading, 
-    error, 
+  const {
+    data,
+    loading,
+    error,
     fetchMore // highlight-line
   } = useQuery<
-    GetLaunchListTypes.GetLaunchList, 
+    GetLaunchListTypes.GetLaunchList,
     GetLaunchListTypes.GetLaunchListVariables
   >(GET_LAUNCHES);
   // same as above
@@ -137,7 +136,7 @@ Copy the code below and add it before the closing `</Fragment>` tag in the `Laun
 <MultiCodeBlock>
 
 ```tsx:title=src/pages/launches.tsx
-{data.launches && 
+{data.launches &&
   data.launches.hasMore && (
     <Button
       onClick={() =>
@@ -168,7 +167,7 @@ Copy the code below and add it before the closing `</Fragment>` tag in the `Laun
 ```
 
 ```jsx:title=src/pages/launches.jsx
-{data.launches && 
+{data.launches &&
   data.launches.hasMore && (
     <Button
       onClick={() =>
@@ -214,8 +213,7 @@ Let's navigate to `src/pages/launch.tsx` to build out our detail page. First, we
 
 ```tsx:title=src/pages/launch.tsx
 import React, { Fragment } from 'react'; // preserve-line
-import { useQuery } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag'; 
+import { gql, useQuery } from '@apollo/client'; // preserve-line
 
 import { Loading, Header, LaunchDetail } from '../components'; // preserve-line
 import { ActionButton } from '../containers'; // preserve-line
@@ -254,17 +252,17 @@ interface LaunchProps extends RouteComponentProps {
 }
 
 const Launch: React.FC<LaunchProps> = ({ launchId }) => {
-  const { 
-    data, 
-    loading, 
-    error 
+  const {
+    data,
+    loading,
+    error
   } = useQuery<
-    LaunchDetailsTypes.LaunchDetails, 
+    LaunchDetailsTypes.LaunchDetails,
     LaunchDetailsTypes.LaunchDetailsVariables
-  >(GET_LAUNCH_DETAILS, 
+  >(GET_LAUNCH_DETAILS,
     { variables: { launchId } }
   );
-  
+
   if (loading) return <Loading />;
   if (error) return <p>ERROR: {error.message}</p>;
   if (!data) return <p>Not found</p>;
@@ -372,8 +370,7 @@ First, let's navigate to `src/pages/profile.tsx` and write our query:
 
 ```tsx:title=src/pages/profile.tsx
 import React, { Fragment } from 'react'; // preserve-line
-import { useQuery } from '@apollo/react-hooks'; // preserve-line
-import gql from 'graphql-tag'; // preserve-line
+import { gql, useQuery } from '@apollo/client'; // preserve-line
 
 import { Loading, Header, LaunchTile } from '../components'; // preserve-line
 import { LAUNCH_TILE_DATA } from './launches'; // preserve-line


### PR DESCRIPTION
Quick win updates covering simple things like using `@apollo/client` instead of `apollo-client`, `@apollo/react-hooks`, `graphql-tag`, etc. This PR does not cover updating content to match the AC3 `fullstack-tutorial` updates made in https://github.com/apollographql/fullstack-tutorial/pull/118. That work is outstanding but is something we'll want to tackle, as the web content of the tutorial is recommending practices we no longer advocate with AC3 (e.g. we have a new pagination approach, we're deprecating local resolvers in favor of type/field policies, etc.).