### PR TITLE
fix for "Cannot read property 'flight_number' of undefined"

### DIFF
--- a/docs/source/tutorial/data-source.md
+++ b/docs/source/tutorial/data-source.md
@@ -98,8 +98,8 @@ Using a reducer like this enables the `getAllLaunches` method to remain concise 
 Our schema also supports fetching an individual launch by its ID. To support this, let's add _two_ methods to the `LaunchAPI` class: `getLaunchById` and `getLaunchesByIds` :
 
 ```js:title=src/datasources/launch.js
-async getLaunchById({ launchId }) {
-  const response = await this.get('launches', { flight_number: launchId });
+async getLaunchById({ launchID }) {
+  const response = await this.get('launches', { flight_number: launchID });
   return this.launchReducer(response[0]);
 }
 


### PR DESCRIPTION
Ran in to a problem on https://www.apollographql.com/docs/tutorial/resolvers/#run-test-queries, running the `GetLaunchById` query in the playground. Instead of returning a launch, hitting "Run" resulted in:
```
 "errors": [
    {
      "message": "Cannot read property 'flight_number' of undefined",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "
```
Upon inspection of the `getLaunchById` method in the `LaunchApi` class, it appears the correct object property is `launchID` not `launchId`.