### PR TITLE
Add missing param on documentation for successfully connection to Apollo Studio

### DIFF
--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -52,7 +52,8 @@ Now, add one extra option to your `ApolloServer` constructor to enable automatic
 const server = new ApolloServer({
   // ...other options...
   engine: {
-    reportSchema: true
+    reportSchema: true,
+    graphVariant: "current"
   }
 });
 ```


### PR DESCRIPTION
Apollo Studio seems to have some changes when creating new graph,I think there is one extra parameter (graphVariant) which seems to be required to successfully receive reports from Apollo server. However it is not reflected on the current docs.  

This pull request adds the missing parameter so that to avoid others to face the same issue as I had when trying to connect without it.