### PR TITLE
Add docs to identify which URLs are used from CLI/AS

### DIFF
--- a/studio-docs/source/data-privacy.md
+++ b/studio-docs/source/data-privacy.md
@@ -4,34 +4,34 @@ sidebar_title: Data privacy and compliance
 description: Understand what Studio ingests and learn about GDPR
 ---
 
-This article describes which data is and is _not_ sent to Apollo as part of its platform's data management tools.
+This article describes which data is and is _not_ sent to Apollo Studio by the other components of the Apollo platform.
+
+Apollo Studio's top priority is ensuring the privacy and security of your data and your customers' data. No Apollo tool sends _any_ data to Apollo Studio unless you configure it to do so. Features that potentially send highly sensitive data require additional opt-in.
 
 > Most importantly, result data from GraphQL operations that your server executes is **never** sent to Apollo.
 
-## What technology sends data to Apollo Studio
+## Which tools send data to Apollo Studio?
 
-In particular, the open source tools that are covered in this document include the [Apollo CLI](https://github.com/apollographql/apollo-tooling/tree/master/packages/apollo) and [Apollo Server](https://github.com/apollographql/apollo-server/). User data is sent to Apollo on an opt-in basis, and we strive to keep the privacy and security of your data top-of-mind, with more sensitive data requiring further opt-in.
+Both [Apollo Server](https://www.apollographql.com/docs/apollo-server/) and the [Apollo CLI](https://www.apollographql.com/docs/devtools/cli/) have **opt-in features** that send data to Apollo Studio. Neither tool sends any data to Studio unless you configure it to do so.
 
-All data is collecting at one of the following endpoints. In some case, there is additional public documentation to enable reporting data directly to these Apollo APIs.
+Apollo Client does **not** send data to Apollo Studio.
 
-* [Usage Reporting](https://www.apollographql.com/docs/studio/setup-analytics/#adding-support-to-a-third-party-server-advanced): https://usage-reporting.api.apollographql.com
-* [Schema Reporting](https://www.apollographql.com/docs/studio/schema/schema-reporting-protocol/) (server): https://engine-graphql.api.apollographql.com
-* [Schema Publishing](https://github.com/apollographql/apollo-tooling/tree/master/packages/apollo-language-server/src/engine/operations) (CLI): https://graphql.api.apollographql.com
+## Where is data sent?
 
-If your setup includes a corporate proxy or firewall, you may need to allow traffic to exit your infrastructure or development machine to these domains. See below for a table on different versions of Apollo Server and the Apollo CLI to see which domain each sends data to. Please note that only hostnames are included; data may be sent to particular endpoints of these domains.
+All data sent to Apollo Studio is sent to an endpoint with one of the following base URLs:
 
-|               | Apollo Server (usage)                     | Apollo Server (schemas)                             |
-|---------------|-------------------------------------------|-----------------------------------------------------|
-| pre - 2.0     | n/a                                       | n/a                                                 |
-| 2.0-2.15.0    | https://engine-report.apollodata.com      | n/a                                                 |
-| 2.15.0-2.17.x | https://engine-report.apollodata.com      | https://edge-server-reporting.api.apollographql.com |
-| 2.17.0 +      | https://usage-reporting.api.apollographql.com | https://schema-reporting.apollographql.com          |
+| Base URL | Used by |
+|----------|---------|
+| **Latest URLs** |
+| `https://usage-reporting.api.apollographql.com` | Metrics reporting from [Apollo Server](https://www.apollographql.com/docs/studio/setup-analytics/#pushing-traces-from-apollo-server) (v2.17.0+) and [third-party API servers](https://www.apollographql.com/docs/studio/setup-analytics/#third-party-support) |
+| `https://schema-reporting.apollographql.com` | Schema registration via schema reporting in [Apollo Server](https://www.apollographql.com/docs/studio/schema/schema-reporting/#apollo-server-setup) (v2.17.0+) and [third-party API servers](https://www.apollographql.com/docs/studio/schema/schema-reporting/#other-graphql-servers) |
+| `https://graphql.api.apollographql.com` | All [Apollo CLI](https://www.apollographql.com/docs/devtools/cli/) (v2.32+) commands that communicate with Studio |
+| **Active legacy URLs** |
+| `https://engine-report.apollodata.com` | Metrics reporting from Apollo Server (v2.0-2.17.x) |
+| `https://edge-server-reporting.api.apollographql.com` | Schema registration via schema reporting in Apollo Server (v2.15.0-2.17.x) |
+| `https://engine-graphql.apollographql.com` | All Apollo CLI (v2.31 and earlier) commands that communicate with Studio |
 
-
-|                  |        Apollo CLI                                     |
-|------------------|-------------------------------------------------------|
-| Pre - 2.31.0     | https://engine-graphql.apollographql.com              |
-| 2.32 +           | https://graphql.api.apollographql.com                 |
+If your environment uses a corporate proxy or firewall, you might need to configure it to allow outbound traffic to these domains. Note that data might be sent to multiple endpoints in a given domain.
 
 ## What data does Apollo Server send to Apollo Studio?
 

--- a/studio-docs/source/data-privacy.md
+++ b/studio-docs/source/data-privacy.md
@@ -8,6 +8,31 @@ This article describes which data is and is _not_ sent to Apollo as part of its 
 
 > Most importantly, result data from GraphQL operations that your server executes is **never** sent to Apollo.
 
+## What technology sends data to Apollo Studio
+
+In particular, the open source tools that are covered in this document include the [Apollo CLI](https://github.com/apollographql/apollo-tooling/tree/master/packages/apollo) and [Apollo Server](https://github.com/apollographql/apollo-server/). User data is sent to Apollo on an opt-in basis, and we strive to keep the privacy and security of your data top-of-mind, with more sensitive data requiring further opt-in.
+
+All data is collecting at one of the following endpoints. In some case, there is additional public documentation to enable reporting data directly to these Apollo APIs.
+
+* [Usage Reporting](https://www.apollographql.com/docs/studio/setup-analytics/#adding-support-to-a-third-party-server-advanced): https://usage-reporting.api.apollographql.com
+* [Schema Reporting](https://www.apollographql.com/docs/studio/schema/schema-reporting-protocol/) (server): https://engine-graphql.api.apollographql.com
+* [Schema Publishing](https://github.com/apollographql/apollo-tooling/tree/master/packages/apollo-language-server/src/engine/operations) (CLI): https://graphql.api.apollographql.com
+
+If your setup includes a corporate proxy or firewall, you may need to allow traffic to exit your infrastructure or development machine to these domains. See below for a table on different versions of Apollo Server and the Apollo CLI to see which domain each sends data to. Please note that only hostnames are included; data may be sent to particular endpoints of these domains.
+
+|               | Apollo Server (usage)                     | Apollo Server (schemas)                             |
+|---------------|-------------------------------------------|-----------------------------------------------------|
+| pre - 2.0     | n/a                                       | n/a                                                 |
+| 2.0-2.15.0    | https://engine-report.apollodata.com      | n/a                                                 |
+| 2.15.0-2.17.x | https://engine-report.apollodata.com      | https://edge-server-reporting.api.apollographql.com |
+| 2.17.0 +      | https://usage-reporting.api.apollographql.com | https://schema-reporting.apollographql.com          |
+
+
+|                  |        Apollo CLI                                     |
+|------------------|-------------------------------------------------------|
+| Pre - 2.31.0     | https://engine-graphql.apollographql.com              |
+| 2.32 +           | https://graphql.api.apollographql.com                 |
+
 ## What data does Apollo Server send to Apollo Studio?
 
 You can configure Apollo Server to trace the execution of each GraphQL operation and [push those metrics to Apollo Studio](./setup-analytics/). Studio uses this trace data to reconstruct both operation-level timing data for given query shapes and field-level timing data for your overall schema. This data is available for you to explore and visualize in Studio.

--- a/studio-docs/source/data-privacy.md
+++ b/studio-docs/source/data-privacy.md
@@ -23,13 +23,13 @@ All data sent to Apollo Studio is sent to an endpoint with one of the following 
 | Base URL | Used by |
 |----------|---------|
 | **Latest URLs** |
-| `https://usage-reporting.api.apollographql.com` | Metrics reporting from [Apollo Server](https://www.apollographql.com/docs/studio/setup-analytics/#pushing-traces-from-apollo-server) (v2.17.0+) and [third-party API servers](https://www.apollographql.com/docs/studio/setup-analytics/#third-party-support) |
-| `https://schema-reporting.apollographql.com` | Schema registration via schema reporting in [Apollo Server](https://www.apollographql.com/docs/studio/schema/schema-reporting/#apollo-server-setup) (v2.17.0+) and [third-party API servers](https://www.apollographql.com/docs/studio/schema/schema-reporting/#other-graphql-servers) |
-| `https://graphql.api.apollographql.com` | All [Apollo CLI](https://www.apollographql.com/docs/devtools/cli/) (v2.32+) commands that communicate with Studio |
+| `https://usage-reporting.api.apollographql.com` | Metrics reporting from [Apollo Server](https://www.apollographql.com/docs/studio/setup-analytics/#pushing-traces-from-apollo-server) (v2.18.0+) and [third-party API servers](https://www.apollographql.com/docs/studio/setup-analytics/#third-party-support) |
+| `https://schema-reporting.apollographql.com` | Schema registration via schema reporting in [Apollo Server](https://www.apollographql.com/docs/studio/schema/schema-reporting/#apollo-server-setup) (v2.18.0+) and [third-party API servers](https://www.apollographql.com/docs/studio/schema/schema-reporting/#other-graphql-servers) |
+| `https://graphql.api.apollographql.com` | All [Apollo CLI](https://www.apollographql.com/docs/devtools/cli/) (v2.31+) commands that communicate with Studio |
 | **Active legacy URLs** |
 | `https://engine-report.apollodata.com` | Metrics reporting from Apollo Server (v2.0-2.17.x) |
 | `https://edge-server-reporting.api.apollographql.com` | Schema registration via schema reporting in Apollo Server (v2.15.0-2.17.x) |
-| `https://engine-graphql.apollographql.com` | All Apollo CLI (v2.31 and earlier) commands that communicate with Studio |
+| `https://engine-graphql.apollographql.com` | All Apollo CLI (v2.30 and earlier) commands that communicate with Studio |
 
 If your environment uses a corporate proxy or firewall, you might need to configure it to allow outbound traffic to these domains. Note that data might be sent to multiple endpoints in a given domain.
 

--- a/studio-docs/source/getting-started.mdx
+++ b/studio-docs/source/getting-started.mdx
@@ -70,7 +70,7 @@ APOLLO_SCHEMA_REPORTING=true
 
 Now whenever your server starts up, it automatically registers its schema with the Apollo schema registry _and_ begins pushing metrics to Apollo Studio!
 
-> We would love for other GraphQL servers to support schema reporting too! If you're interested in implementing support, [the protocol is documented here.](./schema-reporting-protocol/)
+> We would love for other GraphQL servers to support schema reporting too! If you're interested in implementing support, [the protocol is documented here.](./schema/schema-reporting-protocol/)
 
 </ExpansionPanel>
 
@@ -118,7 +118,7 @@ However, to get the most out of Studio, you need to _re_-register your server's 
 
 **If you set up schema reporting** in [Step 3](#3-register-your-schema) (the first schema registration option), Apollo Server automatically registers your schema every time it starts up, and no additional setup is required.
 
-**If you registered your schema with the Apollo CLI**, see [Registering with continuous delivery](./schema/manual-registration/#registering-with-continuous-delivery) for an example.
+**If you registered your schema with the Apollo CLI**, see [Registering with continuous delivery](./schema/cli-registration/#registering-with-continuous-delivery) for an example.
 
 ## Next steps
 

--- a/studio-docs/source/schema-checks.mdx
+++ b/studio-docs/source/schema-checks.mdx
@@ -81,7 +81,7 @@ If your data graph uses [Apollo Federation](https://www.apollographql.com/docs/a
 
 Schema checks is especially useful when you add it to your continuous integration pipeline (such as Jenkins or CircleCI). By doing so, you can obtain results and display them directly on your team's pull requests.
 
-We recommend defining a separate CI job for each [variant of your schema](#checking-against-multiple-environments) (production, staging, etc.) you want to validate your changes against. The `apollo service:check` command returns a non-zero exit code when it detects a breaking change, meaning the job will fail when the check fails.
+We recommend defining a separate CI job for each [variant of your schema](./check-configurations#checking-against-multiple-environments) (production, staging, etc.) you want to validate your changes against. The `apollo service:check` command returns a non-zero exit code when it detects a breaking change, meaning the job will fail when the check fails.
 
 ### Example configuration
 

--- a/studio-docs/source/schema/schema-reporting.mdx
+++ b/studio-docs/source/schema/schema-reporting.mdx
@@ -30,7 +30,7 @@ Now every time your server finishes starting up, it waits a random amount of tim
 
 ### Registering to a variant with schema reporting
 
-Your server can register its schema to a particular [variant of your graph](#managing-environments-with-variants). Each of your server's environments (development, staging, production, etc.) should register to a different variant.
+Your server can register its schema to a particular [variant of your graph](./registry#managing-environments-with-variants). Each of your server's environments (development, staging, production, etc.) should register to a different variant.
 
 To do so with Apollo Server, set the `APOLLO_GRAPH_VARIANT` environment variable in each server environment:
 


### PR DESCRIPTION
Different versions of Apollo Server and the Apollo CLI send data to
different URLs. This adds a section into the "data privacy" document to
indicate which versions of each piece of open source technology send
which data to which domains. This does not include anything about which
data is sent using the Apollo CLI.

In particular, this comes along with an effort that David Glasser is
taking to de-engine-ify our open source technology, and as such update
our domains to use generic *.api.apollographql.com domains. These
changes should not be released until corresponding versions of the CLI
and Apollo Server have landed.