### PR TITLE
docs: update queries.mdx, avoid checking data is defined

### DIFF
--- a/docs/source/tutorial/queries.mdx
+++ b/docs/source/tutorial/queries.mdx
@@ -270,7 +270,7 @@ const Launch: React.FC<LaunchProps> = ({ launchId }) => {
   return (
     <Fragment>
       <Header image={data.launch && data.launch.mission && data.launch.mission.missionPatch}>
-        {data && data.launch && data.launch.mission && data.launch.mission.name}
+        {data.launch && data.launch.mission && data.launch.mission.name}
       </Header>
       <LaunchDetail {...data.launch} />
       <ActionButton {...data.launch} />


### PR DESCRIPTION
We know data is defined here because we have explicitly checked so a few lines above.