### PR TITLE
[Do not merge] Prepare landing page grid for changes to switcher

### DIFF
--- a/docs/source/components/docset-menu.js
+++ b/docs/source/components/docset-menu.js
@@ -6,7 +6,6 @@ import { IconSchema } from '@apollo/space-kit/icons/IconSchema';
 import { ReactComponent as ReactLogo } from '../assets/react-logo.svg';
 import {
   NavItemsContext,
-  NavItemDescription
 } from 'gatsby-theme-apollo-docs';
 import { colors } from '@apollo/space-kit/colors';
 import { size } from 'polished';
@@ -45,15 +44,23 @@ const StyledLink = styled.a({
   }
 });
 
+const MenuItemDescription = styled.p({
+  marginBottom: 0,
+  fontSize: 14,
+  lineHeight: 1.5,
+  color: colors.text3,
+  transition: 'color 150ms ease-in-out'
+});
+
 const icons = [
-  <IconSatellite3 weight="thin" />,
   <ReactLogo />,
-  <IconSchema weight="thin" />,
   <AppleLogo style={{
     padding: 1,
     paddingTop: 0,
     paddingBottom: 2
   }} />,
+  <IconSatellite3 weight="thin" />,
+  <IconSchema weight="thin" />,
 ];
 
 export default function DocsetMenu() {
@@ -72,11 +79,11 @@ export default function DocsetMenu() {
           )}
           title={(
             <StyledLink href={navItem.url}>
-              {navItem.title}
+              {navItem.name}
             </StyledLink>
           )}
         >
-          <NavItemDescription>{navItem.description}</NavItemDescription>
+          <MenuItemDescription>{navItem.description}</MenuItemDescription>
         </MenuItem>
       ))}
     </MenuWrapper>

--- a/docs/source/components/menu.js
+++ b/docs/source/components/menu.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { NavItemTitle } from 'gatsby-theme-apollo-docs';
 import { size } from 'polished';
 import { colors } from '@apollo/space-kit/colors';
 
@@ -9,6 +8,12 @@ export const MenuWrapper = styled.div({
   gridTemplateColumns: `repeat(auto-fill, minmax(270px, 1fr))`,
   gridGap: 24,
   paddingTop: 8
+});
+
+const MenuItemTitle = styled.h4({
+  marginBottom: 8,
+  fontWeight: 600,
+  color: 'inherit'
 });
 
 const MenuItemWrapper = styled.div({
@@ -30,9 +35,9 @@ export function MenuItem({icon, title, children, ...props}) {
     <MenuItemWrapper {...props}>
       <IconWrapper>{icon}</IconWrapper>
       <TextWrapper>
-        <NavItemTitle>
+        <MenuItemTitle>
           {title}
-        </NavItemTitle>
+        </MenuItemTitle>
         {children}
       </TextWrapper>
     </MenuItemWrapper>


### PR DESCRIPTION
Assuming the docset switcher undergoes the current set of changes in https://github.com/apollographql/gatsby-theme-apollo/pull/148, these changes are required to prevent regression for the docs landing page grid