### PR TITLE
Remove more references to engine and graph manager

### DIFF
--- a/docs/source/devtools/cli.md
+++ b/docs/source/devtools/cli.md
@@ -60,11 +60,14 @@ USAGE
 
 COMMANDS
   client:check            Check a client project against a pushed service
-  client:codegen          Generate static types for GraphQL queries. Can use the published
-                          schema in Apollo Studio or a downloaded schema.
-  client:download-schema  Download a schema from Apollo Engine or a GraphQL endpoint.
+  client:codegen          Generate static types for GraphQL queries. Can use the
+                          published schema in the Apollo registry or a
+                          downloaded schema.
+  client:download-schema  Download a schema from Apollo or a GraphQL endpoint in
+                          JSON or SDL format
   client:extract          Extract queries from a client
-  client:push             Register operations with Apollo, adding them to the safelist
+  client:push             Register operations with Apollo, adding them to the
+                          safelist
 ```
 
 You can also obtain the full set of options for an individual command like so:

--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -38,24 +38,15 @@ Your graph API key is the value that appears just after `APOLLO_KEY=` in the fir
 
 You provide your API key to Apollo Server by setting it as the value of the `APOLLO_KEY` environment variable. Conveniently, our example app already uses the `dotenv` package to read environment variables from a `.env` file.
 
-Create a `.env` file in `start/server` by making a copy of `start/server/.env.example`. Then paste your API key into it like so:
+Create a `.env` file in `start/server` by making a copy of `start/server/.env.example`. Then paste your API key into it like so, and add `APOLLO_SCHEMA_REPORTING=true` as well:
 
 ```none:title=.env
 APOLLO_KEY=PASTE_YOUR_KEY_HERE
+APOLLO_SCHEMA_REPORTING=true
 ```
 
 > **Graph API keys are secret credentials.** Never share them outside your organization or commit them to version control. Delete and replace API keys that might be compromised.
 
-Now, add one extra option to your `ApolloServer` constructor to enable automatic schema reporting:
-
-```js:title=index.js
-const server = new ApolloServer({
-  // ...other options...
-  engine: {
-    reportSchema: true
-  }
-});
-```
 
 Start up your server using `npm start`, then return to your Studio homepage. After a few seconds, clicking on your graph will now open its full details.
 

--- a/studio-docs/source/client-awareness.md
+++ b/studio-docs/source/client-awareness.md
@@ -37,26 +37,28 @@ If one or both of these headers are present, Apollo Server automatically extract
 
 #### Advanced Apollo Server configuration
 
-You can configure Apollo Server to use a different method to determine the `name` and `version` of the client associated with a request. To do so, provide a `generateClientInfo` function to the `ApolloServer` constructor.
+You can configure Apollo Server to use a different method to determine the `name` and `version` of the client associated with a request. To do so, install the [usage reporting plugin](https://www.apollographql.com/docs/apollo-server/api/plugin/usage-reporting/) explicitly and provide it with a `generateClientInfo` function.
 
 In the following example, the `generateClientInfo` function calls a `userSuppliedLogic` function, which can return values for the client's name and version based on the details of the `request`.
 
 ```js{8-14}
 const { ApolloServer } = require("apollo-server");
+const { ApolloServerPluginUsageReporting } = require("apollo-server-core");
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
-  engine: {
-    apiKey: 'YOUR API KEY HERE',
-    generateClientInfo: ({ request }) => {
-      const { clientName, clientVersion } = userSuppliedLogic(request);
-      return {
-        clientName,
-        clientVersion
-      };
-    }
-  }
+  plugins: [
+    ApolloServerPluginUsageReporting({
+      generateClientInfo: ({ request }) => {
+        const { clientName, clientVersion } = userSuppliedLogic(request);
+        return {
+          clientName,
+          clientVersion
+        };
+      }
+    })
+  ],
 });
 
 server.listen().then(({ url }) => {

--- a/studio-docs/source/data-privacy.md
+++ b/studio-docs/source/data-privacy.md
@@ -55,7 +55,7 @@ Manager. The responses from your GraphQL service stay internal to your applicati
 
 By default, if Apollo Server sees a response that includes an `errors` field, it reports the values of the error's `message` and `locations` fields (if any) to Apollo Studio.
 
-You can use the [`rewriteError` reporting option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions) to filter or transform errors before they're stored in Studio. Use this to strip sensitive data from errors or filter "safe" errors from Studio reports.
+You can use the [usage reporting plugin's `rewriteError` option](https://www.apollographql.com/docs/apollo-server/api/plugin/usage-reporting/#rewriteerror) to filter or transform errors before they're stored in Studio. Use this to strip sensitive data from errors or filter "safe" errors from Studio reports.
 
 ### Query operation strings
 
@@ -67,14 +67,14 @@ Apollo Server reports the string representation of each query operation to Apoll
 
 In Apollo Server 2.7.0 and later, **none** of an operation's GraphQL variables is sent to Apollo Studio by default.
 
-You can set a value for the [`sendVariableValues` reporting option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting some or all of your GraphQL variables.
+You can set a value for the [usage reporting plugin's `sendVariableValues` option](https://www.apollographql.com/docs/apollo-server/api/plugin/usage-reporting/#sendvariablevalues) to specify a different strategy for reporting some or all of your GraphQL variables.
 
 #### Versions prior to 2.7.0
 
 In versions of Apollo Server 2 _prior_ to 2.7.0, **all** of an operation's GraphQL
 variables are sent to Apollo Studio by default.
 
-If you're using an earlier version of Apollo Server, it's recommended that you update. If you can't update for whatever reason, you can use the [`privateVariables` reporting option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify the names of variables that should _not_ be sent to Studio. You can also set this option to `false` to prevent all variables from being sent. This reporting option is deprecated and will not be available in future versions of Apollo Server.
+If you're using an earlier version of Apollo Server, it's recommended that you update. If you can't update for whatever reason, you can use the [`privateVariables` reporting option](https://www.apollographql.com/docs/apollo-server/migration-engine-plugins/#options-for-apolloserverpluginusagereporting) to specify the names of variables that should _not_ be sent to Studio. You can also set this option to `false` to prevent all variables from being sent. This reporting option is deprecated and will not be available in future versions of Apollo Server.
 
 ### HTTP Headers
 
@@ -94,7 +94,7 @@ You can, however, configure reporting options for all other HTTP headers.
 In Apollo Server 2.7.0 and later, **none** of an
 operation's HTTP headers is sent to Apollo Studio by default.
 
-You can set a value for the [`sendHeaders` reporting option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify a different strategy for reporting
+You can set a value for the [usage reporting plugin's `sendHeaders` option](https://www.apollographql.com/docs/apollo-server/api/plugin/usage-reporting/#sendheaders) to specify a different strategy for reporting
 some or all of your HTTP headers.
 
 #### Versions prior to 2.7.0
@@ -103,7 +103,7 @@ In versions of Apollo Server 2 _prior_ to 2.7.0, **all** of an operation's HTTP 
 (except the confidential headers listed [above](#http-headers)) are sent to Apollo Studio by default.
 
 If you're using an earlier version of Apollo Server, it's recommended that you
-update. If you can't update for whatever reason, you can use the [`privateHeaders` reporting option](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions) to specify the names of variables that should _not_ be sent to Studio. You can also set this option to `false` to prevent all headers from being sent.This reporting option is deprecated and will not be available in future versions of Apollo Server.
+update. If you can't update for whatever reason, you can use the [`privateHeaders` reporting option](https://www.apollographql.com/docs/apollo-server/migration-engine-plugins/#options-for-apolloserverpluginusagereporting) to specify the names of variables that should _not_ be sent to Studio. You can also set this option to `false` to prevent all headers from being sent. This reporting option is deprecated and will not be available in future versions of Apollo Server.
 
 ## What data does Apollo Studio log about operations executed in its Explorer tab?
 

--- a/studio-docs/source/getting-started.mdx
+++ b/studio-docs/source/getting-started.mdx
@@ -58,24 +58,15 @@ Once you have your API key, select the registration method that corresponds  to 
 
 Apollo Server supports a feature called **schema reporting** that enables it to register its schema automatically on startup.
 
-1. Set your graph API key as the value of the `APOLLO_KEY` environment variable in your server's environment.
+Set your graph API key as the value of the `APOLLO_KEY` environment variable in your server's environment, and set the `APOLLO_SCHEMA_REPORTING` environment variable to `true`.
 
-    If you're using the [`dotenv`](https://www.npmjs.com/package/dotenv) library, you can add the API key to the `.env` file in your project's root directory, like so:
+If you're using the [`dotenv`](https://www.npmjs.com/package/dotenv) library, you can add the API key to the `.env` file in your project's root directory, like so:
 
-    ```none:title=.env
-    APOLLO_KEY=YOUR_KEY_HERE
-    ```
+```none:title=.env
+APOLLO_KEY=YOUR_KEY_HERE
+APOLLO_SCHEMA_REPORTING=true
+```
 
-2. Set the `engine.reportSchema` option to `true` in your `ApolloServer` constructor, like so:
-
-    ```js
-    const server = new ApolloServer({
-      // ...other options...
-      engine: {
-        reportSchema: true
-      }
-    });
-    ```
 
 Now whenever your server starts up, it automatically registers its schema with the Apollo schema registry _and_ begins pushing metrics to Apollo Studio!
 

--- a/studio-docs/source/managed-federation/advanced-topics.mdx
+++ b/studio-docs/source/managed-federation/advanced-topics.mdx
@@ -226,7 +226,7 @@ An example output of this behavior looks like this:
                       --endpoint="http://localhost:4001/"
   ✔ Loading Apollo Project
   ✔ Loading Apollo Project
-  ✔ Uploading service to Engine
+  ✔ Uploading service to Apollo
 
 
 The 'launches' service for the 'space-explorer@current' graph was updated
@@ -259,7 +259,7 @@ You might wonder how to guarantee that the changes you're making to your service
                       --serviceURL="http://launches-graphql.svc.cluster.local:4001/" \
                       --endpoint="http://localhost:4001/"
   ✔ Loading Apollo Project
-  ✔ Uploading service to Engine
+  ✔ Uploading service to Apollo
 
 The 'registry' service for the 'space-explorer@current' graph was updated
 

--- a/studio-docs/source/operation-registry.mdx
+++ b/studio-docs/source/operation-registry.mdx
@@ -77,7 +77,7 @@ When successful, this command should return output similar to the following:
 ```
 ✔ Loading Apollo config
 ✔ Fetching current schema
-✔ Publishing <service> to Apollo Engine
+✔ Publishing <service> to Apollo
 
 id      schema        variant
 ------  ------------- -------
@@ -97,7 +97,7 @@ The `apollo client:push` command:
 - Accepts a list of files as a glob (e.g. `src/**/*.ts`) to search for GraphQL operations.
 - By default, includes the `__typename` fields which are added by Apollo Client at runtime.  (Add the `--no-addTypeName` flag to disable this behavior.)
 
-To register operations, use the following command as a reference, taking care to replace the `<ENGINE_API_KEY>` with the appropriate Apollo Studio API key, specifying a unique name for this application with `<CLIENT_IDENTIFIER>`, and indicating the correct glob of files to search:
+To register operations, use the following command as a reference, taking care to replace the `<APOLLO_KEY>` with the appropriate Apollo Studio API key, specifying a unique name for this application with `<CLIENT_IDENTIFIER>`, and indicating the correct glob of files to search:
 
 ```
 npx apollo client:push \
@@ -113,7 +113,7 @@ When successful, the output from this command should look similar to the followi
 
 ```
 ✔ Loading Apollo project
-✔ Pushing client to Engine service <service>
+✔ Pushing operations to operation registry
 ```
 
 Currently, once an operation is registered it will remain registered indefinitely. For production operation registration, it's recommended that operations be registered from a deployment pipeline step rather than manually.
@@ -238,12 +238,12 @@ If the server was not previously configured with Apollo Studio, be sure to start
 APOLLO_KEY=<APOLLO_KEY> npm start
 ```
 
-Alternatively, the API key can be specified with the `engine` parameter on the Apollo Server constructor options:
+Alternatively, the API key can be specified with the `apollo` parameter on the Apollo Server constructor options:
 
 ```js
 const server = new ApolloServer({
   // ...
-  engine: '<APOLLO_KEY>', // highlight-line
+  apollo: { key: '<APOLLO_KEY>' }, // highlight-line
   // ...
 });
 ```
@@ -290,7 +290,7 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   subscriptions: false,
-  engine: '<APOLLO_KEY>',
+  apollo: { key: '<APOLLO_KEY>' },
   plugins: [
     require('apollo-server-plugin-operation-registry')({
       // De-structure the object to get the HTTP `headers` and the GraphQL

--- a/studio-docs/source/performance.md
+++ b/studio-docs/source/performance.md
@@ -82,7 +82,7 @@ The signature algorithm is primarily designed to make it possible to treat opera
 
 Future versions of Apollo Studio are likely to change this default algorithm to leave string literals alone, though it will still be easy to configure your server to remove string literals like in the current implementation. We also intend to stop sending the full raw query in future versions of Studio, so that the signature algorithm really can be used to avoid sending sensitive data in queries to Studio.
 
-But where possible, we strongly advise that you keep sensitive data in GraphQL variables instead of in literal arguments in the query body, as you can more easily control which variables should be stripped out of the Apollo Studio reporting pathway for privacy purposes. See [data privacy](./graph-manager-data-privacy/) for further detail on how this works.
+But where possible, we strongly advise that you keep sensitive data in GraphQL variables instead of in literal arguments in the query body, as you can more easily control which variables should be stripped out of the Apollo Studio reporting pathway for privacy purposes. See [data privacy](./data-privacy/) for further detail on how this works.
 
 ## Error tracking
 

--- a/studio-docs/source/schema/schema-reporting-protocol.mdx
+++ b/studio-docs/source/schema/schema-reporting-protocol.mdx
@@ -15,7 +15,7 @@ A reference implementation of this protocol is included in [Apollo Server](https
 Servers that implement the schema reporting protocol communicate with the following GraphQL endpoint:
 
 ```
-https://edge-server-reporting.api.apollographql.com/api/graphql
+https://schema-reporting.api.apollographql.com/api/graphql
 ```
 
 All requests to this endpoint require a **graph API key** as authentication.

--- a/studio-docs/source/schema/schema-reporting.mdx
+++ b/studio-docs/source/schema/schema-reporting.mdx
@@ -17,23 +17,13 @@ Schema reporting is available in Apollo Server version 2.15 and later. To enable
 
     <ObtainGraphApiKey />
 
-2. Set this API key as the value of the `APOLLO_KEY` environment variable in your server's environment.
+2. Set this API key as the value of the `APOLLO_KEY` environment variable in your server's environment, and set the `APOLLO_SCHEMA_REPORTING` environment variable to `true`.
 
     If you're using the [`dotenv`](https://www.npmjs.com/package/dotenv) library, you can add the API key to the `.env` file in your project's root directory, like so:
 
     ```none:title=.env
     APOLLO_KEY=YOUR_KEY_HERE
-    ```
-
-3. Set the `engine.reportSchema` option to `true` in your `ApolloServer` constructor, like so:
-
-    ```js
-    const server = new ApolloServer({
-      // ...other options...
-      engine: {
-        reportSchema: true
-      }
-    });
+    APOLLO_SCHEMA_REPORTING=true
     ```
 
 Now every time your server finishes starting up, it waits a random amount of time between zero and ten seconds before automatically registering its schema ([you can customize this time range](#customizing-schema-reporting-behavior-in-apollo-server)).
@@ -47,6 +37,7 @@ To do so with Apollo Server, set the `APOLLO_GRAPH_VARIANT` environment variable
 ```none:title=.env
 APOLLO_KEY=YOUR_KEY_HERE
 APOLLO_GRAPH_VARIANT=staging
+APOLLO_SCHEMA_REPORTING=true
 ```
 
 If you don't specify a variant, Apollo Server reports its schema to the default variant (named `current`).
@@ -65,25 +56,9 @@ To provide these values to Apollo Server, set the following environment variable
 
 ### Customizing schema reporting behavior in Apollo Server
 
-In addition to `engine.reportSchema`, you can provide the following options to Apollo Server to modify schema reporting defaults:
+Schema reporting is implemented via a plugin called `ApolloServerPluginSchemaReporting`. When you set the `APOLLO_SCHEMA_REPORTING` environment variable to `true`, Apollo Server automatically installs that plugin with its default configuration.
 
-| Name  | Type | Description  |
-|---|---|---|
-| `engine.overrideReportedSchema` | String | <p>If provided, Apollo Server sends this string value as the schema to register.</p><p>By default, Apollo Server sends its interpreted `GraphQLSchema` object (the same value it returns from an introspection request) as an SDL string. This default behavior is appropriate for the majority of use cases.</p> |
-| `engine.schemaReportingInitialDelayMaxMs` | Integer | <p>On startup, Apollo Server waits a random number of milliseconds between `0` and this value before attempting to register its schema. This helps stagger registration requests when you deploy multiple instances of your server simultaneously.</p><p>The default value is `10000` (10 seconds).</p>|
-
-For example, the following value for `engine.overrideReportedSchema` provides a schema definition directly from Apollo Server's `typeDefs` object, instead of the interpreted `GraphQLSchema` created from that object:
-
-```js{5}
-const server = new ApolloServer({
-  typeDefs,
-  resolvers,
-  engine: {
-    reportSchema: true
-    overrideReportedSchema: typeDefs.loc && typeDefs.loc.source.body
-  }
-});
-```
+If you need to configure the plugin further, you can explicitly install the plugin in your server. For example, you can tweak the amount of time that Apollo Server waits on startup before attempting to register its schema, or you can override the actual schema string that is registered. See the [schema reporting plugin reference](https://www.apollographql.com/docs/apollo-server/api/plugin/schema-reporting/) for more details.
 
 ## Other GraphQL servers
 

--- a/studio-docs/source/setup-analytics.mdx
+++ b/studio-docs/source/setup-analytics.mdx
@@ -55,7 +55,7 @@ You can set up a reporting agent in your GraphQL server to push metrics to Apoll
 * Emitting batches of traces to the Apollo Studio reporting endpoint
 * Optionally defining plugins to enable advanced reporting features
 
-Apollo Server defines its agent for performing these tasks in [`agent.ts`](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-engine-reporting/src/agent.ts).
+Apollo Server defines its agent for performing these tasks in [the usage reporting plugin](https://github.com/apollographql/apollo-server/tree/main/packages/apollo-server-core/src/plugin/usageReporting).
 
 > If you're interested in collaborating with Apollo on creating a dedicated integration for your GraphQL server, please get in touch with us at **support@apollographql.com** or via our [Apollo Spectrum Community](https://spectrum.chat/apollo).
 
@@ -63,13 +63,13 @@ Apollo Server defines its agent for performing these tasks in [`agent.ts`](https
 
 Apollo Studio's reporting endpoint accepts batches of traces that are encoded in **protocol buffer** format. Each trace corresponds to the execution of a single GraphQL operation, including a breakdown of the timing and error information for each field that's resolved as part of the operation.
 
-The schema for this protocol buffer is defined as the `FullTracesReport` message in the [TypeScript reference implementation](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-engine-reporting-protobuf/src/reports.proto#L466). 
+The schema for this protocol buffer is defined as the `Report` message in the [TypeScript reference implementation](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-reporting-protobuf/src/reports.proto).
 
-As a starting point, we recommend implementing an extension to the GraphQL execution that creates a report with a single trace, as defined in the `Trace` message of [the protobuf schema](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-engine-reporting-protobuf/src/reports.proto#L7). Then, you can batch multiple traces into a single report. We recommend sending batches approximately every 20 seconds, and limiting each batch to a reasonable size (~4MB).
+As a starting point, we recommend implementing an extension to the GraphQL execution that creates a report with a single trace, as defined in the `Trace` message of [the protobuf schema](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-reporting-protobuf/src/reports.proto). Then, you can batch multiple traces into a single report. We recommend sending batches approximately every 20 seconds, and limiting each batch to a reasonable size (~4MB).
 
 An example of a `FullTracesReport` message, represented as JSON, is provided [below](#example-fulltracesreport-message).
 
-> Many server runtimes already support emitting tracing information as a [GraphQL extension](https://github.com/apollographql/apollo-tracing). Such extensions are available for [Node](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-engine-reporting/src/extension.ts), [Ruby](https://github.com/uniiverse/apollo-tracing-ruby), [Scala](https://github.com/sangria-graphql/sangria-slowlog#apollo-tracing-extension), [Java](https://github.com/graphql-java/graphql-java/pull/577), [Elixir](https://github.com/sikanhe/apollo-tracing-elixir), and [.NET](https://graphql-dotnet.github.io/docs/getting-started/metrics/). If you're working on adding metrics reporting functionality for one of these languages, reading through that tracing instrumentation is a good place to start. For other languages, we recommend consulting the [Apollo Server instrumentation](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-engine-reporting/src/extension.ts).
+> Many server runtimes already support emitting tracing information as a [GraphQL extension](https://github.com/apollographql/apollo-tracing). Such extensions are available for [Node](https://www.apollographql.com/docs/apollo-server/api/plugin/usage-reporting/), [Ruby](https://github.com/uniiverse/apollo-tracing-ruby), [Scala](https://github.com/sangria-graphql/sangria-slowlog#apollo-tracing-extension), [Java](https://github.com/graphql-java/graphql-java/pull/577), [Elixir](https://github.com/sikanhe/apollo-tracing-elixir), and [.NET](https://graphql-dotnet.github.io/docs/getting-started/metrics/). If you're working on adding metrics reporting functionality for one of these languages, reading through that tracing instrumentation is a good place to start. For other languages, we recommend consulting the [Apollo Server usage reporting plugin](https://github.com/apollographql/apollo-server/tree/main/packages/apollo-server-core/src/plugin/usageReporting).
 
 ### Operation signing
 
@@ -101,7 +101,7 @@ query AuthorForPost {
 }
 ```
 
-It's important to decide how to group such queries when tracking metrics. The [TypeScript reference implementation](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-engine-reporting/src/signature.ts) does the following to every query before generating its signature to better group functionally equivalent operations:
+It's important to decide how to group such queries when tracking metrics. The [TypeScript reference implementation](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-graphql/src/operationId.ts) does the following to every query before generating its signature to better group functionally equivalent operations:
 
 * Drop unused fragments and/or operations
 * Hide string literals
@@ -116,7 +116,7 @@ We recommend using the same default signature method for consistency across diff
 After your GraphQL server prepares a batch of traces, it should send them to the Studio reporting endpoint at the following URL:
 
 ```
-https://engine-report.apollodata.com/api/ingress/traces
+https://usage-reporting.api.apollographql.com/api/ingress/traces
 ```
 
 Each batch should be sent as an HTTP POST request. The body of the request can be one of the following:
@@ -133,7 +133,7 @@ Only graph-level API keys (starting with the prefix `service:`) are supported.
 
 The request can also optionally include a `Content-Type` header with value `application/protobuf`, but this is not required.
 
-For a reference implementation, see the `sendReport()` method in the [TypeScript reference agent](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-engine-reporting/src/agent.ts#L210).
+For a reference implementation, see the `sendReport()` function in the [TypeScript reference agent](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts).
 
 #### Tuning reporting behavior
 
@@ -141,7 +141,7 @@ We recommend implementing retries with backoff when you encounter `5xx` response
 
 ### Implementing additional reporting features
 
-The reference TypeScript implementation includes several features that you might want to include in your implementation. All of these features are implemented in the agent itself, and are documented in the interface description for the `EngineReportingOptions` of [the agent](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-engine-reporting/src/agent.ts#L48).
+The reference TypeScript implementation includes several features that you might want to include in your implementation. All of these features are implemented in the usage reporting plugin itself, and are documented [the plugin's API reference](https://www.apollographql.com/docs/apollo-server/api/plugin/usage-reporting/).
 
 For example, you can restrict which information is sent to Studio, particularly to avoid reporting personal data. Because personal data most commonly appears in variables and headers, the TypeScript agent offers options to `sendVariablesValues` and `sendHeaders`.
 


### PR DESCRIPTION
Update AS configuration docs to use the new v2.18 plugin API (or just to use
APOLLO_SCHEMA_REPORTING=true rather than code to turn on schema reporting).