### PR TITLE
docs: Add new description change codes to schema-checks.mdx

### DIFF
--- a/studio-docs/source/schema-checks.mdx
+++ b/studio-docs/source/schema-checks.mdx
@@ -307,4 +307,21 @@ These changes are detected by the `apollo service:check` command, but they are "
       </li>
     </ul>
   </li>
+  <li>
+    Descriptions
+    <ul>
+      <li id ="TYPE_DESCRIPTION_CHANGE">
+        <code>TYPE_DESCRIPTION_CHANGE</code> Description added, removed, or updated for a type.
+      </li>
+      <li id ="FIELD_DESCRIPTION_CHANGE">
+        <code>FIELD_DESCRIPTION_CHANGE</code> Description added, removed, or updated for a field.
+      </li>
+      <li id ="ENUM_VALUE_DESCRIPTION_CHANGE">
+        <code>ENUM_VALUE_DESCRIPTION_CHANGE</code> Description added, removed, or updated for an enum value.
+      </li>
+      <li id ="ARG_DESCRIPTION_CHANGE">
+        <code>ARG_DESCRIPTION_CHANGE</code> Description added, removed, or updated for an argument.
+      </li>
+    </ul>
+  </li>
 </ul>


### PR DESCRIPTION
Our GraphQL API has new description change codes, and our history page will link to the checks docs page for each of those new change codes shortly.

This PR adds those new change codes to the checks docs page. Note that unlike other change codes, `CHANGE` in description change codes may refer to an addition, removal, or update (for other change codes, `CHANGE` refers to just an update).