### PR TITLE
Edit tutorial mutations readme

### DIFF
--- a/docs/source/tutorial/mutation-resolvers.md
+++ b/docs/source/tutorial/mutation-resolvers.md
@@ -125,10 +125,7 @@ GraphQL mutations are structured exactly like queries, except they use the `muta
 
 ```graphql
 mutation LoginUser {
-  login(email: "daisy@apollographql.com") {
-    email
-    token
-  }
+  login(email: "daisy@apollographql.com")
 }
 ```
 
@@ -136,11 +133,8 @@ The server will respond like this:
 
 ```
   "data": {
-    "login": {
-      "email": "daisy@apollographql.com",
-      "token": "ZGFpc3lAYXBvbGxvZ3JhcGhxbC5jb20="
-      }               
-     }
+    "login": "ZGFpc3lAYXBvbGxvZ3JhcGhxbC5jb20="    
+  }
 ```
 
 The string below is your login token (which is just the Base64 encoding of the email address you provided). Copy it to use in the next mutation.


### PR DESCRIPTION
Field login must not have a selection since type String has no subfields.
Our login mutation return string, not object