### PR TITLE
Add a doc for the Explorer to the Studio docs

### DIFF
--- a/studio-docs/gatsby-config.js
+++ b/studio-docs/gatsby-config.js
@@ -17,7 +17,7 @@ module.exports = {
           null: [
             'index',
             'getting-started',
-            '[Explorer](https://studio.apollographql.com/explorer)',
+            'explorer',
             '[Managed federation](https://apollographql.com/docs/federation/managed-federation/overview/)',
           ],
           'Registering your Schema': [

--- a/studio-docs/source/data-privacy.md
+++ b/studio-docs/source/data-privacy.md
@@ -134,9 +134,9 @@ In versions of Apollo Server 2 _prior_ to 2.7.0, **all** of an operation's HTTP 
 If you're using an earlier version of Apollo Server, it's recommended that you
 update. If you can't update for whatever reason, you can use the [`privateHeaders` reporting option](https://www.apollographql.com/docs/apollo-server/migration-engine-plugins/#options-for-apolloserverpluginusagereporting) to specify the names of variables that should _not_ be sent to Studio. You can also set this option to `false` to prevent all headers from being sent. This reporting option is deprecated and will not be available in future versions of Apollo Server.
 
-## What data does Apollo Studio log about operations executed in its Explorer tab?
+## What data does Apollo Studio log about operations executed in the Explorer?
 
-**Only front-end usage metrics for improving the product.** The Explorer tab in Apollo Studio enables you to build and execute operations against your GraphQL server. These operations are sent directly from your browser and **do not** pass through Studio servers.
+**Only front-end usage metrics for improving the product.** The [Apollo Studio Explorer](./explorer/) enables you to build and execute operations against your GraphQL server. These operations are sent directly from your browser and **do not** pass through Studio servers.
 
 ## GDPR
 

--- a/studio-docs/source/explorer.mdx
+++ b/studio-docs/source/explorer.mdx
@@ -1,20 +1,27 @@
 ---
-title: Explorer
-sidebar_title: Explorer
+title: The Apollo Studio Explorer
+sidebar_title: The Explorer
 ---
 
-The Explorer in Studio is a GraphQL client for authoring and managing your operations.
+The Apollo Studio Explorer is an interface for creating, running, and managing GraphQL operations:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/j8b0Bda_TIw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 It provides a rich workspace, complete with all the basics of query editing (syntax highlighting, autocomplete, etc.) and a significant number of additive features that are entirely unique to the Explorer.
 
-We know how important it is that your developer tools _stay out of your way_, and the Explorer has been designed and built with great care for the small details and nuance of editing environments.
+> Operations in the Explorer are sent directly from your browser to your GraphQL server, _without_ passing through Apollo's systems. Apollo does not ever see your request headers or response data.
 
-## Editor basics
+## Setup
 
-The Explorer’s operation editor is built on Monaco, and includes all the usual conventions we expect from query-building tools (such as ⌘+Enter to run, state persistence across sessions, and panels for providing headers and variables). The editor also provides full IntelliSense support for GraphQL, including query linting, autocomplete, peek definitions on hover, jump-to-definition with a command-click, and more.
+To get started with the Explorer, [create a graph](./getting-started/#2-create-your-first-graph) in Studio and navigate to the Explorer tab. The Explorer will ask you for the URL of your running GraphQL server when you try to run your first query. You can change this URL at any time from the Explorer's Settings tab.
+
+## The operation editor
+
+The Explorer’s operation editor is built on [Monaco](https://microsoft.github.io/monaco-editor/), and includes all the usual conventions we expect from query-building tools (such as ⌘+Enter to run, state persistence across sessions, and panels for providing headers and variables). The editor also provides full IntelliSense support for GraphQL, including query linting, autocomplete, peek definitions on hover, jump-to-definition with a command-click, and more.
 
 The editor is also able to manage multiple operations and reason about those operations individually. As you're working, the editor will shift focus to whichever operation you've clicked in to. Each operation has its own context menu where you can copy its contents to CURL, copy a link to share, format it, etc.
 
-## Query building
+## Building a query
 
 The Explorer's three column layout lets you keep your schema's documentation open at all times if you'd like.
 
@@ -42,47 +49,82 @@ After you identify which type-field pair you want, the Explorer runs a breadth-f
 
 Step 2 of search walks you through the available paths one step at a time to narrow down your options before choosing your final path. There can sometimes be thousands of path options to a single location in the graph, and some filtering at that point is very helpful.
 
-## Features
+## Additional features
 
 Beyond the basics of query editing, query building, and search, the Explorer has a number of other rich features. Most of these features are unique to the Explorer and not available in other GraphQL clients.
 
-### Dark mode
+### Authentication
 
-The Explorer comes in both light mode and dark mode, because we don't think we could have lived without both.
+The Explorer currently provides the following options for authentication. If your graph has authentication requirements that aren't covered by these options, please contact us at **support@apollographql.com** with questions or feedback.
 
-### Subscriptions support
+#### Request headers
 
-The Explorer comes with first-class support for running subscriptions. You can run queries, mutations, and subscriptions all within the same workspace (no need for separate tabs). You can start and stop listening to your subscriptions at will and see new information as it comes in and old information as it goes stale. You can set your websocket endpoint independently from your http endpoint.
+The bottom of the Explorer editor provides a Headers section where you can set headers that are included in your operation's HTTP request.
 
-### Operation history
+For example, you can provide a bearer token in an `Authentication` header like so:
 
-The Explorer will save a small history of the queries and variables you've run recently to your local storage and provide you with access to them via the History tab. This is helpful when trying to recover previous work and keep your workspace clean while retaining past operations.
+```json
+{
+  "Authentication": "bearer <TOKEN>"
+}
+```
 
-### Mocked responses
+> **Beta feature:** You can specify default headers that are applied to _every_ Explorer request executed by _every_ user in your organization. This can be useful if you want to provide a consistent identifier to your server for requests coming from the Explorer. To request access to this beta feature, please contact **support@apollographql.com**.
 
-You can turn on the "Mock responses" option in the Explorer Settings page. This will naively mock responses based on the types in your schema, rather then sending your operations over the wire to your endpoint. This can be helpful if you want to get a feel for what your query responses will be without having an endpoint available, or if you want to get a mocked response to use as a sample or put in a test.
+#### Cookies
 
-### Download responses
+If your graph authenticates using cookies, you can configure your endpoint to share those cookies with https://studio.apollographql.com.
 
-You can copy responses from your operations with a button or download any given response to a local JSON file.
+Once configured, requests sent from https://studio.apollographql.com will carry the cookies from your domain when you run queries with the Explorer. If you're logged in on your domain, requests from the Explorer will also be logged in. If you log out on your domain and the cookie is removed, requests from the Explorer will be logged out.
 
-### Response hints
+To set this up, your [cookie's value must contain `SameSite=None; Secure`](https://www.chromium.org/updates/same-site). Additionally, these CORS headers must be present in your server's response to Studio:
 
-You can turn on the "Use response hints" option in the Explorer Settings. As you build your query, the Explorer will run partial queries under the hood and show you their results inlined in the editor. This is helpful when trying to get a sense of the data you'll get back in your full operation response, and can also be really helpful to get quick answers from queries without having to even hit the Run button.
+```bash
+Access-Control-Allow-Origin: https://studio.apollographql.com
+Access-Control-Allow-Credentials: true
+```
 
-The Explorer will not show hints for mutations (we don't want to be running partial mutations).
+#### Preflight Scripts (beta)
 
-### Field latency hints
+> To request access to preflight scripts, contact **support@apollographql.com**.
 
-As an alternative to response hints, the Explorer can also show you hints for the general latency of the fields in your query. This is an option that's available if you've set your graph up to also report field usage and tracing data to Studio.
+[Much like Postman](https://learning.postman.com/docs/writing-scripts/pre-request-scripts/), we have an ability for you to execute JavaScript before your request runs.
+This capability can be used to facilitate parts of the OAuth flow. In particular, preflight scripts are very useful for using refresh tokens to keep your authentication tokens valid without constant manual intervention.
 
-The Explorer will show you the 95th percentile response times for the fields in your query to help you get a sense of "how expensive" your query is and what the bottlenecks in response time will be.
+Preflight scripts can also be persisted to users across your account, so you can set up an authentication script for your graph and other members of your team will be able to use it as well.
 
-### `graphql-lodash` integration
+We have [detailed documentation on how preflight scripts work](https://github.com/apollographql/apollo-studio-community/blob/main/preview-docs/PreRequestScripts.md).
+If this would be useful to you, please get in touch with support@apollographql.com to request access for your account.
 
-The Explorer [extends your schema with `graphql-lodash`](https://github.com/APIs-guru/graphql-lodash) on the client side, so you can write queries that include lodash directives and they will resolve correctly. This is quite helfpul if you want to manipulate your response data into into a specific format for exporting, or of if you want to do some quick analysis without needing to export.
+### Building operations
 
-Here's an example of a query using `graphql-lodash`. You can try pasting this in the Explorer embedded at http://apollographql.com/studio/develop:
+#### Mocked responses
+
+> Enable **Mock responses** from the Explorer's Settings tab.
+
+This feature naively mocks operation responses based on your schema's types, instead of sending your operations over the wire to your endpoint.
+
+Mocked responses are helpful if you want to get a feel for the shape of a query's response when your endpoint isn't available, or if you need a quick response to use in a code sample or a unit test.
+
+#### Response hints
+
+> Enable **Use response hints** from the Explorer's Settings tab.
+
+As you build your query, the Explorer runs partial queries under the hood and shows their results in-line. This is helpful when you want to get a sense of the data you'll get back in your full operation response. It can also help you retrieve a quick answer to a query without needing to click the Run button.
+
+The Explorer does not show response hints for mutations (this requires running partial mutations, which is unsafe).
+
+#### Field latency hints
+
+As an alternative to [response hints](#response-hints), the Explorer can show you hints for the latency of the fields in your query. This option is available only if you've configured your graph to [report field usage and tracing data to Studio](./setup-analytics/).
+
+The Explorer shows you the 95th-percentile response times for the fields in your query to help you get a sense of "how expensive" your query is and what the bottlenecks in response time will be.
+
+#### `graphql-lodash` integration
+
+The Explorer [extends your schema with `graphql-lodash`](https://github.com/APIs-guru/graphql-lodash) on the client side, so you can write queries that include lodash directives and they will resolve correctly. This is helfpul if you want to manipulate your response data into into a specific format for exporting, or if you want to do some quick analysis without needing to export.
+
+Here's an example of a query that uses `graphql-lodash`. You can try pasting this in the Explorer embedded at http://apollographql.com/studio/develop:
 
 ```graphql:title=example.graphql
 query StarWarsGenderStats {
@@ -96,11 +138,7 @@ query StarWarsGenderStats {
 }
 ```
 
-### View responses in table form
-
-You can view any response from a query or mutation as either JSON or a table. If you turn on table mode, the Explorer will do its best to render your data in table form. This is extremely useful when trying to read arrays of data and generally makes your data more readable, especially to folks who aren't developers.
-
-### Inline/Extract variables
+#### Inline/Extract variables
 
 At any point when editing your operations, you can switch between inlined or extracted variable notation with the click of one button. This is an option in "..." context menu next to each of your operations.
 
@@ -132,77 +170,65 @@ query($id: ID!) {
 }
 ```
 
-### Query plans for federated graphs
+### Local development
+
+Unline similar GraphQL clients, the Explorer obtains your server's schema from Apollo Studio by default, _not_ by introspecting your server. This has the following benefits:
+
+* The Explorer can provide documentation and schema IntelliSense, even if your endpoint has disabled introspection (this is common for production graphs).
+* The Explorer can provide information about directives, which introspection does not support.
+
+You can still use the Explorer for local development. To do so, create a [development graph](https://studio.apollographql.com/dev) in Studio.
+
+A dev graph uses introspection to fetch your schema from your local endpoint, and it also polls regularly for changes. Whenever a new schema is detected, the dev graph pulls this change and updates itself automatically. You can also pause introspection polling at any time.
+
+### Saving operations
+
+#### Operation history
+
+> View your operation history from the Explorer's **Run history** tab.
+
+The Explorer saves the history of your recently run operations (and the variable values for those operations) to your browser's local storage. Access your history to retain and recover previous work without cluttering your editor.
+
+#### Downloading responses
+
+You can copy responses from your operations with a button or download any given response to a local JSON file.
+
+### Networking
+
+#### CORS policies
+
+Requests from the Explorer go straight from your browser to your GraphQL server, so your endpoint will see requests coming from the `https://studio.apollographql.com` domain.
+
+It's common for public endpoints to have CORS policies that restrict which domains can query them. If your endpoint has CORS protections enabled, you probably need to safe-list https://studio.apollographql.com in your CORS policy to use the Explorer.
+
+If you can't change your CORS policy, you might be able to write a small proxy to your endpoint and point the Explorer to the proxy instead. CORS policies are enforced by browsers, and the proxy won't have the same issues communicating to your endpoint.
+
+### Federation
+
+#### Query plans for federated graphs
 
 If you're working with a federated graph in Studio, the Explorer will dynamically calculate query plans for your in the right panel (an option under the Responses tab). As you edit your query, the Explorer will recalculate your query plans and show you their updates.
 
-## Setup
 
-To use the Explorer, create a graph in Studio and navigate to the Explorer page. The Explorer will ask you where your graph is running when you try to run your first query. You can change the URL the Explorer makes requests to at any time under the Explorer Settings tab.
+### Display
 
-Queries in the Explorer are sent directly from your browser to your endpoint and do not pass through Apollo's systems. Apollo does not ever see your request headers or your response data.
+#### Dark mode
 
-### CORS policies
+Toggle between light and dark mode from the Explorer's Settings tab.
 
-Requests from the Explorer go straight from your browser to your endpoint, so your endpoint will see requests coming from https://studio.apollographql.com domain.
+#### Table layout for response data
 
-It is common for public endpoints to have CORS policies that restrict which domains are allowed to query them. If your endpoint has CORS protections enabled, you will likely need to safe-list https://studio.apollographql.com in your CORS policy to use the Explorer.
+You can view an operation's response as JSON or as a table. Table layout is especially useful when your response includes an array, or when you want to share a query's results with someone who isn't familiar with JSON.
 
-If changing your CORS policy is not possible, another option is to write a small proxy to your endpoint, and to point the Explorer to your proxy instead. CORS policies are enforced by browsers, and your proxy will not have the same issues communicating to your endpoint.
 
-## Local development
+## FAQ
 
-Unline other GraphQL clients, the Explorer will is load its schema context from what you register to Studio by default, not from introspecting your graph. The benefits of this approach are that:
+### Does the Explorer support subscription operations?
 
-- We can provide documentation and schema intellisense even when your endpoint may have introspection turned off (common in production).
-- We can provide information about directives, which introspection does not support.
+Yes. You can run queries, mutations, and subscriptions all from the same Explorer page. You can start and stop listening to subscriptions, and you can see new subscription data as it comes in and old information as it becomes stale. 
 
-If you want to use the Explorer for local development and to have it actively listen for changes and update itself, you should create a "Development" graph in Studio (https://studio.apollographql.com/dev).
+You can also set your server's subscription websocket endpoint independently from the HTTP endpoint for queries and mutations.
 
-Dev graphs will introspect your local endpoint and poll for changes. If a new schema is detected, dev graphs will pull this change and update themselves automatically without you having to refresh anything. Dev graphs have a setting where you can pause introspection polling if you want to.
+### Is the Explorer available for on-prem distribution?
 
-## Authentication
-
-There are a few basic options for setting up authentication with the Explorer right now.
-We are very open to hearing about your authentication requirements and to working with you direction to set up authentication to your graph from within the Explorer.
-Please don't hesitate to reach out to support@apollographql.com with questions on authentication – we'll be in touch.
-
-### Headers
-
-There is a headers section of the Explorer editor where you can set authentication headers. It is common to authenticate by setting tokens in that area directly:
-
-```json
-{
-  "Authentication": "bearer <TOKEN>"
-}
-```
-
-> **Note:** If you would like to configure your graph to add default headers for any request from the Explorer (across all users in your account), this feature is available in beta form. Please get in touch with support@apollographql.com to request access. This can be useful if you need to send a consistent identifier or override for requests coming from the Explorer, for example.
-
-### Cookies
-
-If your graph authenticates using cookies, you can configure your endpoint to share those cookies with https://studio.apollographql.com.
-
-Once set up, requests sent from https://studio.apollographql.com will carry the cookies from your domain when you run queries with the Explorer.
-If you're logged in on your domain, requests from the Explorer will be logged in. Once you log out on your domain and the cookie is removed, requests from the Explorer will be logged out.
-
-To set this up, your [cookie's value must contain `SameSite=None; Secure`](https://www.chromium.org/updates/same-site) and these CORS headers must be present in your server's response to Studio:
-
-```bash
-Access-Control-Allow-Origin: https://studio.apollographql.com
-Access-Control-Allow-Credentials: true
-```
-
-### Preflight Scripts (beta, available on request)
-
-[Much like Postman](https://learning.postman.com/docs/writing-scripts/pre-request-scripts/), we have an ability for you to execute JavaScript before your request runs.
-This capability can be used to facilitate parts of the OAuth flow. In particular, preflight scripts are very useful for using refresh tokens to keep your authentication tokens valid without constant manual intervention.
-
-Preflight scripts can also be persisted to users across your account, so you can set up an authentication script for your graph and other members of your team will be able to use it as well.
-
-We have [detailed documentation on how preflight scripts work](https://github.com/apollographql/apollo-studio-community/blob/main/preview-docs/PreRequestScripts.md).
-If this would be useful to you, please get in touch with support@apollographql.com to request access for your account.
-
-## Distribution
-
-Right now the Explorer is available for free, unlimited use in Apollo Studio. It is not available for download or on-prem distribution at this time. This is something we have given considerable thought to and may do in the future, but our goal for now is to build the best possible Explorer experience for you from within Studio.
+Not at this time. The Explorer is available for free, unlimited use in Apollo Studio, but it is not available for download or on-prem distribution. This might change in the future, but for now our goal is to provide the best possible Explorer experience from within Studio.

--- a/studio-docs/source/explorer.mdx
+++ b/studio-docs/source/explorer.mdx
@@ -1,0 +1,208 @@
+---
+title: Explorer
+sidebar_title: Explorer
+---
+
+The Explorer in Studio is a GraphQL client for authoring and managing your operations.
+It provides a rich workspace, complete with all the basics of query editing (syntax highlighting, autocomplete, etc.) and a significant number of additive features that are entirely unique to the Explorer.
+
+We know how important it is that your developer tools _stay out of your way_, and the Explorer has been designed and built with great care for the small details and nuance of editing environments.
+
+## Editor basics
+
+The Explorer’s operation editor is built on Monaco, and includes all the usual conventions we expect from query-building tools (such as ⌘+Enter to run, state persistence across sessions, and panels for providing headers and variables). The editor also provides full IntelliSense support for GraphQL, including query linting, autocomplete, peek definitions on hover, jump-to-definition with a command-click, and more.
+
+The editor is also able to manage multiple operations and reason about those operations individually. As you're working, the editor will shift focus to whichever operation you've clicked in to. Each operation has its own context menu where you can copy its contents to CURL, copy a link to share, format it, etc.
+
+## Query building
+
+The Explorer's three column layout lets you keep your schema's documentation open at all times if you'd like.
+
+The documentation in the Explorer is designed to let you "step into your schema". As you step further, it keeps track of your current path. This path helps you navigate back up your schema via breadcrumbs, and it tells Explorer exactly how to reach your current location from the root.
+
+At any point, you can click the (+) button next to a field in the documentation and the Explorer will add that field to your query along the path you've walked through the docs. The Explorer will also automatically generate variables for you (a preference you can turn on/off, but variable notation is sometimes tedious to write out).
+
+The query builder will help you build variables just as it helps you build queries. Clicking the (+) next to input objects will help you generate JSON in your Variables editor just as easily as it helps you build your operations.
+
+## Search
+
+The Explorer comes with a two-step search that helps you both identify what you're looking for in your schema, and then **a path to get to there**. The second step here is especially crucial because search mechanisms are not complete in the context of query building if they do not help you find _how_ to get what you want once you've identified what you're looking for.
+
+This is one of the things we felt was most lacking in GraphQL tooling before the Explorer.
+
+### Step 1: Identify a field
+
+The first step of search helps you identify exactly which type-field pairing you’re looking for.
+
+If you know you’re looking for a field named `email`, the Explorer helps you identify whether you want `User.email` or `Organization.email`. And if you’re less sure about the field’s name, Explorer uses a fuzzy search, so you can get it a little wrong. You can also include a `.` modifier to search both type and field names simultaneously, which can help you narrow in on the perfect match.
+
+### Step 2: Find a path to the field
+
+After you identify which type-field pair you want, the Explorer runs a breadth-first search from your schema’s entry points (`Query`, `Mutation` and `Subscription`) to the chosen field. It lists all of the paths it finds, ordered by length. After you select which path you want, the Explorer opens it for you in the Documentation panel, and you can add it to your query with a click.
+
+Step 2 of search walks you through the available paths one step at a time to narrow down your options before choosing your final path. There can sometimes be thousands of path options to a single location in the graph, and some filtering at that point is very helpful.
+
+## Features
+
+Beyond the basics of query editing, query building, and search, the Explorer has a number of other rich features. Most of these features are unique to the Explorer and not available in other GraphQL clients.
+
+### Dark mode
+
+The Explorer comes in both light mode and dark mode, because we don't think we could have lived without both.
+
+### Subscriptions support
+
+The Explorer comes with first-class support for running subscriptions. You can run queries, mutations, and subscriptions all within the same workspace (no need for separate tabs). You can start and stop listening to your subscriptions at will and see new information as it comes in and old information as it goes stale. You can set your websocket endpoint independently from your http endpoint.
+
+### Operation history
+
+The Explorer will save a small history of the queries and variables you've run recently to your local storage and provide you with access to them via the History tab. This is helpful when trying to recover previous work and keep your workspace clean while retaining past operations.
+
+### Mocked responses
+
+You can turn on the "Mock responses" option in the Explorer Settings page. This will naively mock responses based on the types in your schema, rather then sending your operations over the wire to your endpoint. This can be helpful if you want to get a feel for what your query responses will be without having an endpoint available, or if you want to get a mocked response to use as a sample or put in a test.
+
+### Download responses
+
+You can copy responses from your operations with a button or download any given response to a local JSON file.
+
+### Response hints
+
+You can turn on the "Use response hints" option in the Explorer Settings. As you build your query, the Explorer will run partial queries under the hood and show you their results inlined in the editor. This is helpful when trying to get a sense of the data you'll get back in your full operation response, and can also be really helpful to get quick answers from queries without having to even hit the Run button.
+
+The Explorer will not show hints for mutations (we don't want to be running partial mutations).
+
+### Field latency hints
+
+As an alternative to response hints, the Explorer can also show you hints for the general latency of the fields in your query. This is an option that's available if you've set your graph up to also report field usage and tracing data to Studio.
+
+The Explorer will show you the 95th percentile response times for the fields in your query to help you get a sense of "how expensive" your query is and what the bottlenecks in response time will be.
+
+### `graphql-lodash` integration
+
+The Explorer [extends your schema with `graphql-lodash`](https://github.com/APIs-guru/graphql-lodash) on the client side, so you can write queries that include lodash directives and they will resolve correctly. This is quite helfpul if you want to manipulate your response data into into a specific format for exporting, or of if you want to do some quick analysis without needing to export.
+
+Here's an example of a query using `graphql-lodash`. You can try pasting this in the Explorer embedded at http://apollographql.com/studio/develop:
+
+```graphql:title=example.graphql
+query StarWarsGenderStats {
+  genderStats: allPeople @_(get: "edges") {
+    edges @_(countBy: "node.gender") {
+      node {
+        gender
+      }
+    }
+  }
+}
+```
+
+### View responses in table form
+
+You can view any response from a query or mutation as either JSON or a table. If you turn on table mode, the Explorer will do its best to render your data in table form. This is extremely useful when trying to read arrays of data and generally makes your data more readable, especially to folks who aren't developers.
+
+### Inline/Extract variables
+
+At any point when editing your operations, you can switch between inlined or extracted variable notation with the click of one button. This is an option in "..." context menu next to each of your operations.
+
+This is extremely useful when you want to switch modes to quickly copy and paste something, or when you are drafting a query in the editor and wanting to move it to code.
+
+Inlined variable:
+
+```graphql:title=query.graphql
+query {
+  user(id: "Beth Harmon") {
+    name
+  }
+}
+```
+
+Extraced variable:
+
+```graphql:title=query.graphql
+query($id: ID!) {
+  user(id: $id) {
+    name
+  }
+}
+```
+
+```json:title=variables.json
+{
+  "id": "Beth Harmon"
+}
+```
+
+### Query plans for federated graphs
+
+If you're working with a federated graph in Studio, the Explorer will dynamically calculate query plans for your in the right panel (an option under the Responses tab). As you edit your query, the Explorer will recalculate your query plans and show you their updates.
+
+## Setup
+
+To use the Explorer, create a graph in Studio and navigate to the Explorer page. The Explorer will ask you where your graph is running when you try to run your first query. You can change the URL the Explorer makes requests to at any time under the Explorer Settings tab.
+
+Queries in the Explorer are sent directly from your browser to your endpoint and do not pass through Apollo's systems. Apollo does not ever see your request headers or your response data.
+
+### CORS policies
+
+Requests from the Explorer go straight from your browser to your endpoint, so your endpoint will see requests coming from https://studio.apollographql.com domain.
+
+It is common for public endpoints to have CORS policies that restrict which domains are allowed to query them. If your endpoint has CORS protections enabled, you will likely need to safe-list https://studio.apollographql.com in your CORS policy to use the Explorer.
+
+If changing your CORS policy is not possible, another option is to write a small proxy to your endpoint, and to point the Explorer to your proxy instead. CORS policies are enforced by browsers, and your proxy will not have the same issues communicating to your endpoint.
+
+## Local development
+
+Unline other GraphQL clients, the Explorer will is load its schema context from what you register to Studio by default, not from introspecting your graph. The benefits of this approach are that:
+
+- We can provide documentation and schema intellisense even when your endpoint may have introspection turned off (common in production).
+- We can provide information about directives, which introspection does not support.
+
+If you want to use the Explorer for local development and to have it actively listen for changes and update itself, you should create a "Development" graph in Studio (https://studio.apollographql.com/dev).
+
+Dev graphs will introspect your local endpoint and poll for changes. If a new schema is detected, dev graphs will pull this change and update themselves automatically without you having to refresh anything. Dev graphs have a setting where you can pause introspection polling if you want to.
+
+## Authentication
+
+There are a few basic options for setting up authentication with the Explorer right now.
+We are very open to hearing about your authentication requirements and to working with you direction to set up authentication to your graph from within the Explorer.
+Please don't hesitate to reach out to support@apollographql.com with questions on authentication – we'll be in touch.
+
+### Headers
+
+There is a headers section of the Explorer editor where you can set authentication headers. It is common to authenticate by setting tokens in that area directly:
+
+```json
+{
+  "Authentication": "bearer <TOKEN>"
+}
+```
+
+> **Note:** If you would like to configure your graph to add default headers for any request from the Explorer (across all users in your account), this feature is available in beta form. Please get in touch with support@apollographql.com to request access. This can be useful if you need to send a consistent identifier or override for requests coming from the Explorer, for example.
+
+### Cookies
+
+If your graph authenticates using cookies, you can configure your endpoint to share those cookies with https://studio.apollographql.com.
+
+Once set up, requests sent from https://studio.apollographql.com will carry the cookies from your domain when you run queries with the Explorer.
+If you're logged in on your domain, requests from the Explorer will be logged in. Once you log out on your domain and the cookie is removed, requests from the Explorer will be logged out.
+
+To set this up, your [cookie's value must contain `SameSite=None; Secure`](https://www.chromium.org/updates/same-site) and these CORS headers must be present in your server's response to Studio:
+
+```bash
+Access-Control-Allow-Origin: https://studio.apollographql.com
+Access-Control-Allow-Credentials: true
+```
+
+### Preflight Scripts (beta, available on request)
+
+[Much like Postman](https://learning.postman.com/docs/writing-scripts/pre-request-scripts/), we have an ability for you to execute JavaScript before your request runs.
+This capability can be used to facilitate parts of the OAuth flow. In particular, preflight scripts are very useful for using refresh tokens to keep your authentication tokens valid without constant manual intervention.
+
+Preflight scripts can also be persisted to users across your account, so you can set up an authentication script for your graph and other members of your team will be able to use it as well.
+
+We have [detailed documentation on how preflight scripts work](https://github.com/apollographql/apollo-studio-community/blob/main/preview-docs/PreRequestScripts.md).
+If this would be useful to you, please get in touch with support@apollographql.com to request access for your account.
+
+## Distribution
+
+Right now the Explorer is available for free, unlimited use in Apollo Studio. It is not available for download or on-prem distribution at this time. This is something we have given considerable thought to and may do in the future, but our goal for now is to build the best possible Explorer experience for you from within Studio.

--- a/studio-docs/source/explorer.mdx
+++ b/studio-docs/source/explorer.mdx
@@ -3,55 +3,67 @@ title: The Apollo Studio Explorer
 sidebar_title: The Explorer
 ---
 
-The Apollo Studio Explorer is an interface for creating, running, and managing GraphQL operations:
+The Apollo Studio Explorer is a powerful web IDE for creating, running, and managing GraphQL operations:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/j8b0Bda_TIw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-It provides a rich workspace, complete with all the basics of query editing (syntax highlighting, autocomplete, etc.) and a significant number of additive features that are entirely unique to the Explorer.
-
-> Operations in the Explorer are sent directly from your browser to your GraphQL server, _without_ passing through Apollo's systems. Apollo does not ever see your request headers or response data.
+The Explorer is free for all Apollo Studio organizations. It supports all GraphQL operation types (`Query`, `Mutation`, and `Subscription`).
 
 ## Setup
 
-To get started with the Explorer, [create a graph](./getting-started/#2-create-your-first-graph) in Studio and navigate to the Explorer tab. The Explorer will ask you for the URL of your running GraphQL server when you try to run your first query. You can change this URL at any time from the Explorer's Settings tab.
+To get started with the Explorer, [create a graph](./getting-started/#2-create-your-first-graph) in Apollo Studio and then navigate to the graph's Explorer tab.
 
-## The operation editor
+The Getting Started tab _within_ the Explorer helps you get up and running with core features.
 
-The Explorer’s operation editor is built on [Monaco](https://microsoft.github.io/monaco-editor/), and includes all the usual conventions we expect from query-building tools (such as ⌘+Enter to run, state persistence across sessions, and panels for providing headers and variables). The editor also provides full IntelliSense support for GraphQL, including query linting, autocomplete, peek definitions on hover, jump-to-definition with a command-click, and more.
-
-The editor is also able to manage multiple operations and reason about those operations individually. As you're working, the editor will shift focus to whichever operation you've clicked in to. Each operation has its own context menu where you can copy its contents to CURL, copy a link to share, format it, etc.
+When you execute your first query, the Explorer prompts you for the URL of your running GraphQL server. You can then change this URL at any time from the Explorer's Settings tab.
 
 ## Building a query
 
-The Explorer's three column layout lets you keep your schema's documentation open at all times if you'd like.
+### The operation editor
 
-The documentation in the Explorer is designed to let you "step into your schema". As you step further, it keeps track of your current path. This path helps you navigate back up your schema via breadcrumbs, and it tells Explorer exactly how to reach your current location from the root.
+The Explorer’s operation editor is built on [Monaco](https://microsoft.github.io/monaco-editor/). It provides common features of query-building tools, including:
 
-At any point, you can click the (+) button next to a field in the documentation and the Explorer will add that field to your query along the path you've walked through the docs. The Explorer will also automatically generate variables for you (a preference you can turn on/off, but variable notation is sometimes tedious to write out).
+* Panels for specifying headers and variables
+* Persistence across sessions
+* Keyboard shortcuts (click the keyboard icon in the bottom-right corner of the operation editor to view all available shortcuts)
 
-The query builder will help you build variables just as it helps you build queries. Clicking the (+) next to input objects will help you generate JSON in your Variables editor just as easily as it helps you build your operations.
+The editor also provides full IntelliSense support for GraphQL, including:
 
-## Search
+* Query linting
+* Autocomplete
+* Peek definitions on mouse hover
+* Jump-to-definition with command-click
 
-The Explorer comes with a two-step search that helps you both identify what you're looking for in your schema, and then **a path to get to there**. The second step here is especially crucial because search mechanisms are not complete in the context of query building if they do not help you find _how_ to get what you want once you've identified what you're looking for.
+The editor can manage multiple operations and reason about those operations individually. As you work, the editor shifts focus to whichever operation you click into. Each operation has its own context menu ("**...**") that enables you to format it, copy a link to share, or generate a `curl` command.
 
-This is one of the things we felt was most lacking in GraphQL tooling before the Explorer.
+### The Documentation tab
 
-### Step 1: Identify a field
+The Explorer's Documentation tab enables you to step into your schema, beginning at one of its entry points. As you step into a field and its subfields, the Explorer keeps track of your current path within the schema.
 
-The first step of search helps you identify exactly which type-field pairing you’re looking for.
+You can click the **⊕** button next to any field in the Documentation tab to add that field to the operation editor, at your current path. By default, the Explorer automatically generates variables for that field's arguments.
 
-If you know you’re looking for a field named `email`, the Explorer helps you identify whether you want `User.email` or `Organization.email`. And if you’re less sure about the field’s name, Explorer uses a fuzzy search, so you can get it a little wrong. You can also include a `.` modifier to search both type and field names simultaneously, which can help you narrow in on the perfect match.
+## Searching your schema
 
-### Step 2: Find a path to the field
+The Explorer provides a two-step schema search (shortcut `⌘+K`):
 
-After you identify which type-field pair you want, the Explorer runs a breadth-first search from your schema’s entry points (`Query`, `Mutation` and `Subscription`) to the chosen field. It lists all of the paths it finds, ordered by length. After you select which path you want, the Explorer opens it for you in the Documentation panel, and you can add it to your query with a click.
+1. Find the schema field you're looking for
+2. Find the ideal _path_ to that field from your schema's entry points
 
-Step 2 of search walks you through the available paths one step at a time to narrow down your options before choosing your final path. There can sometimes be thousands of path options to a single location in the graph, and some filtering at that point is very helpful.
+### 1. Find a field
+
+First, you search for a field by its name (e.g., `email`). The interface helps you differentiate between fields with the same name (e.g., `User.email` versus `Organization.email`). The search is "fuzzy", so it works even if you don't know a field's exact spelling.
+
+If you know exactly which type and which field you're looking for, you can separate those values with a period (e.g., `User.email`).
+
+### 2. Find a path to the field
+
+After you identify a type-field pair, the Explorer lists all of the _paths_ to that field that start at your schema's entry points (`Query`, `Mutation` and `Subscription`). These paths are ordered by depth.
+
+> Finding the path to a field is particularly important with GraphQL, because you can only query a field if that field's position within your query is valid. 
+
+After you select which path you want, the Explorer opens that path in its Documentation tab. You can then click the **⊕** button to add that path to your query.
 
 ## Additional features
-
-Beyond the basics of query editing, query building, and search, the Explorer has a number of other rich features. Most of these features are unique to the Explorer and not available in other GraphQL clients.
 
 ### Authentication
 
@@ -88,15 +100,98 @@ Access-Control-Allow-Credentials: true
 
 > To request access to preflight scripts, contact **support@apollographql.com**.
 
-[Much like Postman](https://learning.postman.com/docs/writing-scripts/pre-request-scripts/), we have an ability for you to execute JavaScript before your request runs.
-This capability can be used to facilitate parts of the OAuth flow. In particular, preflight scripts are very useful for using refresh tokens to keep your authentication tokens valid without constant manual intervention.
+[Similar to Postman](https://learning.postman.com/docs/writing-scripts/pre-request-scripts/), the Explorer can execute custom JavaScript before your request runs. This feature is especially useful for managing OAuth, for example by refreshing an access token automatically.
 
-Preflight scripts can also be persisted to users across your account, so you can set up an authentication script for your graph and other members of your team will be able to use it as well.
+You can save preflight scripts to your organization, meaning all users in your organization can use them.
 
-We have [detailed documentation on how preflight scripts work](https://github.com/apollographql/apollo-studio-community/blob/main/preview-docs/PreRequestScripts.md).
-If this would be useful to you, please get in touch with support@apollographql.com to request access for your account.
+For more information, see the [documentation for preflight scripts](https://github.com/apollographql/apollo-studio-community/blob/main/preview-docs/PreRequestScripts.md).
 
-### Building operations
+### Display
+
+#### Dark mode
+
+> Toggle between light and dark mode from the Explorer's Settings tab.
+
+#### Table layout for response data
+
+> Toggle between table and JSON layout from the top of the Explorer's Response panel.
+
+You can view an operation's response as JSON or as a table. Table layout is especially useful when your response includes an array, or when you want to share a query's results with someone who isn't familiar with JSON.
+
+#### Inline/Extract variables
+
+> Click the "**...**" menu next to an operation in the editor to select a notation for variables.
+
+While editing your operations, you can toggle between inline or extracted notation for variables. This is useful when you want to switch notations to copy and paste something, or when you're drafting a query in the editor and want to move it to your code.
+
+##### Inline variable
+
+```graphql:title=query.graphql
+query {
+  user(id: "Beth Harmon") {
+    name
+  }
+}
+```
+
+##### Extracted variable
+
+```graphql:title=query.graphql
+query($id: ID!) {
+  user(id: $id) {
+    name
+  }
+}
+```
+
+```json:title=variables.json
+{
+  "id": "Beth Harmon"
+}
+```
+
+### Federation
+
+#### Query plans for federated graphs
+
+If you're working with a federated graph in Studio, the Explorer dynamically calculates query plans for your operations in the right-jpanel (an option under the Responses tab). As you edit your query, the Explorer will recalculate your query plans and show you their updates.
+
+
+
+### Local development
+
+Unline similar GraphQL clients, the Explorer obtains your server's schema from Apollo Studio by default, _not_ by introspecting your server. This has the following benefits:
+
+* The Explorer can provide documentation and schema IntelliSense, even if your endpoint has disabled introspection (this is common for production graphs).
+* The Explorer can provide information about directives, which introspection does not support.
+
+You can still use the Explorer for local development. To do so, create a [development graph](https://studio.apollographql.com/dev) in Studio.
+
+A dev graph uses introspection to fetch your schema from your local endpoint, and it also polls regularly for changes. Whenever a new schema is detected, the dev graph pulls this change and updates itself automatically. You can also pause introspection polling at any time.
+
+### Networking
+
+#### CORS policies
+
+Requests from the Explorer go straight from your browser to your GraphQL server, so your endpoint will see requests coming from the `https://studio.apollographql.com` domain.
+
+It's common for public endpoints to have CORS policies that restrict which domains can query them. If your endpoint has CORS protections enabled, you probably need to safe-list https://studio.apollographql.com in your CORS policy to use the Explorer.
+
+If you can't change your CORS policy, you might be able to write a small proxy to your endpoint and point the Explorer to the proxy instead. CORS policies are enforced by browsers, and the proxy won't have the same issues communicating to your endpoint.
+
+### Saving operations
+
+#### Operation history
+
+> View your operation history from the Explorer's **Run history** tab.
+
+The Explorer saves the history of your recently run operations (and the variable values for those operations) to your browser's local storage. Access your history to retain and recover previous work without cluttering your editor.
+
+#### Downloading responses
+
+You can copy responses from your operations with a button or download any given response to a local JSON file.
+
+### Testing operations
 
 #### Mocked responses
 
@@ -118,7 +213,7 @@ The Explorer does not show response hints for mutations (this requires running p
 
 As an alternative to [response hints](#response-hints), the Explorer can show you hints for the latency of the fields in your query. This option is available only if you've configured your graph to [report field usage and tracing data to Studio](./setup-analytics/).
 
-The Explorer shows you the 95th-percentile response times for the fields in your query to help you get a sense of "how expensive" your query is and what the bottlenecks in response time will be.
+The Explorer shows you the 95th-percentile response times for the fields in your query to help you get a sense of how "expensive" your query is and what the bottlenecks in response time will be.
 
 #### `graphql-lodash` integration
 
@@ -138,89 +233,6 @@ query StarWarsGenderStats {
 }
 ```
 
-#### Inline/Extract variables
-
-At any point when editing your operations, you can switch between inlined or extracted variable notation with the click of one button. This is an option in "..." context menu next to each of your operations.
-
-This is extremely useful when you want to switch modes to quickly copy and paste something, or when you are drafting a query in the editor and wanting to move it to code.
-
-Inlined variable:
-
-```graphql:title=query.graphql
-query {
-  user(id: "Beth Harmon") {
-    name
-  }
-}
-```
-
-Extraced variable:
-
-```graphql:title=query.graphql
-query($id: ID!) {
-  user(id: $id) {
-    name
-  }
-}
-```
-
-```json:title=variables.json
-{
-  "id": "Beth Harmon"
-}
-```
-
-### Local development
-
-Unline similar GraphQL clients, the Explorer obtains your server's schema from Apollo Studio by default, _not_ by introspecting your server. This has the following benefits:
-
-* The Explorer can provide documentation and schema IntelliSense, even if your endpoint has disabled introspection (this is common for production graphs).
-* The Explorer can provide information about directives, which introspection does not support.
-
-You can still use the Explorer for local development. To do so, create a [development graph](https://studio.apollographql.com/dev) in Studio.
-
-A dev graph uses introspection to fetch your schema from your local endpoint, and it also polls regularly for changes. Whenever a new schema is detected, the dev graph pulls this change and updates itself automatically. You can also pause introspection polling at any time.
-
-### Saving operations
-
-#### Operation history
-
-> View your operation history from the Explorer's **Run history** tab.
-
-The Explorer saves the history of your recently run operations (and the variable values for those operations) to your browser's local storage. Access your history to retain and recover previous work without cluttering your editor.
-
-#### Downloading responses
-
-You can copy responses from your operations with a button or download any given response to a local JSON file.
-
-### Networking
-
-#### CORS policies
-
-Requests from the Explorer go straight from your browser to your GraphQL server, so your endpoint will see requests coming from the `https://studio.apollographql.com` domain.
-
-It's common for public endpoints to have CORS policies that restrict which domains can query them. If your endpoint has CORS protections enabled, you probably need to safe-list https://studio.apollographql.com in your CORS policy to use the Explorer.
-
-If you can't change your CORS policy, you might be able to write a small proxy to your endpoint and point the Explorer to the proxy instead. CORS policies are enforced by browsers, and the proxy won't have the same issues communicating to your endpoint.
-
-### Federation
-
-#### Query plans for federated graphs
-
-If you're working with a federated graph in Studio, the Explorer will dynamically calculate query plans for your in the right panel (an option under the Responses tab). As you edit your query, the Explorer will recalculate your query plans and show you their updates.
-
-
-### Display
-
-#### Dark mode
-
-Toggle between light and dark mode from the Explorer's Settings tab.
-
-#### Table layout for response data
-
-You can view an operation's response as JSON or as a table. Table layout is especially useful when your response includes an array, or when you want to share a query's results with someone who isn't familiar with JSON.
-
-
 ## FAQ
 
 ### Does the Explorer support subscription operations?
@@ -232,3 +244,7 @@ You can also set your server's subscription websocket endpoint independently fro
 ### Is the Explorer available for on-prem distribution?
 
 Not at this time. The Explorer is available for free, unlimited use in Apollo Studio, but it is not available for download or on-prem distribution. This might change in the future, but for now our goal is to provide the best possible Explorer experience from within Studio.
+
+### Do my Explorer operations pass through Apollo servers?
+
+No. Operations you run in the Explorer are sent directly from your browser to your GraphQL server, _without_ passing through Apollo's systems. Apollo never sees your request headers or response data. For more information, see [Apollo Studio data privacy and compliance](./data-privacy).

--- a/studio-docs/source/getting-started.mdx
+++ b/studio-docs/source/getting-started.mdx
@@ -94,9 +94,11 @@ After you register your schema, select your graph in [Apollo Studio](https://stu
 
 ## 4. Explore your schema
 
-Now that your schema's registered, you're ready to try out one of Studio's most powerful features: the **Explorer tab**. This view provides visibility into your entire schema and helps you build and run queries against it.
+Now that your schema's registered, you're ready to try out one of Studio's most powerful features: the **Explorer**. This tool provides visibility into your entire schema and helps you build and run queries against it.
 
 From [Apollo Studio](https://studio.apollographql.com/), select your graph and open its Explorer tab. Complete its Getting Started steps to see what it can do!
+
+> [Learn more about the Apollo Studio Explorer](./explorer/)
 
 ## 5. Connect to Slack
 

--- a/studio-docs/source/index.mdx
+++ b/studio-docs/source/index.mdx
@@ -16,7 +16,7 @@ import CalloutCard from "../components/callout-card";
 * The [Apollo schema registry](./schema/registry/), which tracks changes
 and enables you to [create variants of your schema](./schema/registry/#managing-environments-with-variants) for different environments
 (such as staging and production)
-* A powerful **schema explorer** that helps your team build and run queries against your registered schema ([watch a demo video](https://www.youtube.com/watch?v=j8b0Bda_TIw))
+* A powerful [Explorer](./explorer/) that helps your team build and run queries against your registered schema
 * [Metrics reporting](https://www.apollographql.com/docs/studio/setup-analytics/) for up to the last 24 hours
 * Team collaboration via [organizations](./org/organizations/)
 * [Slack notifications](./slack-integration/) for schema changes and daily metrics reports

--- a/studio-docs/source/schema/registry.mdx
+++ b/studio-docs/source/schema/registry.mdx
@@ -6,9 +6,9 @@ The **Apollo schema registry** is a central hub for managing your data graph. Af
 
 You can register your schema either with a feature called [schema reporting](./schema-reporting/) (recommended) or by uploading a schema with the [Apollo CLI](./cli-registration/).
 
-## The Explorer tab
+## The Explorer
 
-[The Explorer tab](https://studio.apollographql.com/explorer) in Apollo Studio enables you to navigate the entirety of your schema and execute operations against it directly from your browser:
+[The Apollo Studio Explorer](../explorer/) enables you to navigate the entirety of your schema and execute operations against it directly from your browser:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/j8b0Bda_TIw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 


### PR DESCRIPTION
Turns out the https://studio.apollographql.com/explorer link is now broken and I didn't realize it, and so I thought I'd take the opportunity to replace that broken link with a dedicated doc on the Explorer that I think we've needed for a while.

I'm not sure what the right place to put this doc is in the structure. Current place seems neither great nor awful to me 🤷 

This document:
- goes over all the basics of the Explorer (editor, query building, search –– mostly lifted from the announcement post)
- goes over setup (CORS), authentication, and distribution
- most importantly: adds a feature list for everything we've added so far (most of which is unique to the Explorer among other GraphQL querying tools), adds the list in a way that we can expand upon easily