### PR TITLE
fix typo in resolver.md

### DIFF
--- a/docs/source/tutorial/resolvers.md
+++ b/docs/source/tutorial/resolvers.md
@@ -235,7 +235,7 @@ User: {
 },
 ```
 
-You might be wondering how our server knows the identity of the current user when calling functions like `getLaunchIDsByUser`. It doesn't yet! We'll fix that in the next chapter.
+You might be wondering how our server knows the identity of the current user when calling functions like `getLaunchIdsByUser`. It doesn't yet! We'll fix that in the next chapter.
 
 ## Paginate results
 


### PR DESCRIPTION
There is no `getLaunchIDsByUser ` in the  `final/server/src/datasources/user.js`.

Just a typo.