### PR TITLE
studio docs: graph roles & protected variants

### DIFF
--- a/studio-docs/shared/obtain-graph-api-key.mdx
+++ b/studio-docs/shared/obtain-graph-api-key.mdx
@@ -14,9 +14,7 @@ import {
 
     **Otherwise**, proceed to the next step.
 
-2. Open your graph's Settings page and scroll down to the API Keys section. Either copy an existing key or click **Create New Key**.
-
-3. Optionally click the `…` button to the right of the API key to give it a name, such as `Production`. This helps you keep track of each API key's use.
+3. Open your graph's Settings page and scroll down to the API Keys section. Either copy an existing key or click **Create New Key**. Give your key a name, such as `Production`. This helps you keep track of each API key's use.
 
 4. Copy the key's value.
 

--- a/studio-docs/shared/obtain-personal-api-key.mdx
+++ b/studio-docs/shared/obtain-personal-api-key.mdx
@@ -8,10 +8,8 @@ import {
 
 1. Go to [studio.apollographql.com/user-settings](https://studio.apollographql.com/user-settings).
 
-2. In the Personal API Key section, click **Create New Key**. Your new API key appears in the Token column of the table.
+2. In the Personal API Key section, click **Create New Key**. Give your key a name, such as `Local development laptop`. This helps you keep track of each API key's use.
 
-3. Optionally click the `…` button to the right of the API key to give it a name, such as `Local development laptop`. This helps you keep track of each API key's use.
-
-4. Copy the key's value.
+3. Copy the key's value.
 
 </ExpansionPanel>

--- a/studio-docs/source/api-keys.mdx
+++ b/studio-docs/source/api-keys.mdx
@@ -10,29 +10,29 @@ Every application that sends data to Apollo must use an **API key** to do so. Ap
 
 ## Graph API keys
 
-A graph API key provides **full** access to a **single graph** in Apollo Studio. A GraphQL server (such as Apollo Server) can use a graph API key to register its schema and push metrics to Studio.
-
-> If your organization has an enterprise subscription, you will be able to [**assign a role**](/org/members/#member-roles) to your graph API keys when you create them. These are the same roles that you can assign to users in your organization. The role an API key has cannot be changed after it is created; you must create a new key if you want to enforce a different role.
+A graph API key provides access to a **single graph** in Apollo Studio. A GraphQL server (such as Apollo Server) can use a graph API key to register its schema and push metrics to Studio.
 
 Create a unique graph API key for each non-development system that communicates with Studio. Doing so enables you to revoke access to a single system without affecting others.
 
 <ObtainGraphApiKey />
 
+### Setting permissions
+
+Unless you have an Enterprise plan, every graph API key provides **full access** to its associated graph.
+
+If you have an Enterprise plan, you can [assign a member role](/org/members/#member-roles) to each graph API key you create. If you do, the API key's permissions are limited to that role's permissions.
+
+You can't change a graph API key's role after it's created. Instead, create a new key with the desired role.
+
 ## Personal API keys
 
-A personal API key provides **partial** access to **every graph in every organization you belong to**.
+A personal API key provides partial access to **every graph in every organization you belong to**. A personal API key has the same permissions that your user account has in each of your organizations. 
 
-You can use personal API keys with the Apollo CLI and VS Code extensions to load data (usually schemas) from Studio.
-Specifically, the Apollo [CLI](https://www.apollographql.com/docs/devtools/cli/) and [VS Code extension](https://www.apollographql.com/docs/devtools/editor-plugins/) can be set up using personal API keys, but almost all other Studio interactions require a graph API key.
+You can use personal API keys with local development tools (like the Apollo [CLI](https://www.apollographql.com/docs/devtools/cli/) and [VS Code extension](https://www.apollographql.com/docs/devtools/editor-plugins/)) to load schemas and other data from Studio.
 
-
-
-Interactions that require a graph API key include:
+However, a [graph API key](#graph-api-keys) is required for almost all other Studio interactions, including:
 
 * Schema registration via [schema reporting](../schema/schema-reporting/)
 * [Metrics reporting](../setup-analytics/)
-
-
-Every interaction that's performed using a personal API key is associated with the corresponding user. Your personal API keys will have the exact same permissions as your user. If you need to limit which permissions your token has, use a graph API key.
 
 <ObtainPersonalApiKey />

--- a/studio-docs/source/api-keys.mdx
+++ b/studio-docs/source/api-keys.mdx
@@ -12,13 +12,20 @@ Every application that sends data to Apollo must use an **API key** to do so. Ap
 
 A graph API key provides **full** access to a **single graph** in Apollo Studio. A GraphQL server (such as Apollo Server) can use a graph API key to register its schema and push metrics to Studio.
 
+> If your organization has an enterprise subscription, you will be able to [**assign a role**](/org/members/#member-roles) to your graph API keys when you create them. These are the same roles that you can assign to users in your organization. The role an API key has cannot be changed after it is created; you must create a new key if you want to enforce a different role.
+
 Create a unique graph API key for each non-development system that communicates with Studio. Doing so enables you to revoke access to a single system without affecting others.
 
 <ObtainGraphApiKey />
 
 ## Personal API keys
 
-A personal API key provides **partial** access to **every graph in every organization you belong to**. Specifically, the Apollo [CLI](https://www.apollographql.com/docs/devtools/cli/) and [VS Code extension](https://www.apollographql.com/docs/devtools/editor-plugins/) support personal API keys, but all other Studio interactions require a graph API key.
+A personal API key provides **partial** access to **every graph in every organization you belong to**.
+
+You can use personal API keys with the Apollo CLI and VS Code extensions to load data (usually schemas) from Studio.
+Specifically, the Apollo [CLI](https://www.apollographql.com/docs/devtools/cli/) and [VS Code extension](https://www.apollographql.com/docs/devtools/editor-plugins/) can be set up using personal API keys, but almost all other Studio interactions require a graph API key.
+
+
 
 Interactions that require a graph API key include:
 
@@ -26,6 +33,6 @@ Interactions that require a graph API key include:
 * [Metrics reporting](../setup-analytics/)
 
 
-Every interaction that's performed using a personal API key is associated with the corresponding user.
+Every interaction that's performed using a personal API key is associated with the corresponding user. Your personal API keys will have the exact same permissions as your user. If you need to limit which permissions your token has, use a graph API key.
 
 <ObtainPersonalApiKey />

--- a/studio-docs/source/api-keys.mdx
+++ b/studio-docs/source/api-keys.mdx
@@ -20,7 +20,7 @@ Create a unique graph API key for each non-development system that communicates 
 
 Unless you have an Enterprise plan, every graph API key provides **full access** to its associated graph.
 
-If you have an Enterprise plan, you can [assign a member role](/org/members/#member-roles) to each graph API key you create. If you do, the API key's permissions are limited to that role's permissions.
+If you have an Enterprise plan, you can [assign a member role](/org/members/#organization-wide-member-roles) to each graph API key you create. If you do, the API key's permissions are limited to that role's permissions.
 
 You can't change a graph API key's role after it's created. Instead, create a new key with the desired role.
 

--- a/studio-docs/source/api-keys.mdx
+++ b/studio-docs/source/api-keys.mdx
@@ -28,11 +28,6 @@ You can't change a graph API key's role after it's created. Instead, create a ne
 
 A personal API key provides partial access to **every graph in every organization you belong to**. A personal API key has the same permissions that your user account has in each of your organizations. 
 
-You can use personal API keys with local development tools (like the Apollo [CLI](https://www.apollographql.com/docs/devtools/cli/) and [VS Code extension](https://www.apollographql.com/docs/devtools/editor-plugins/)) to load schemas and other data from Studio.
-
-However, a [graph API key](#graph-api-keys) is required for almost all other Studio interactions, including:
-
-* Schema registration via [schema reporting](../schema/schema-reporting/)
-* [Metrics reporting](../setup-analytics/)
+You will likely want to use personal API keys with local development tools (like the Apollo [CLI](https://www.apollographql.com/docs/devtools/cli/) and [VS Code extension](https://www.apollographql.com/docs/devtools/editor-plugins/)) to load schemas and other data from Studio.
 
 <ObtainPersonalApiKey />

--- a/studio-docs/source/org/graphs.mdx
+++ b/studio-docs/source/org/graphs.mdx
@@ -16,11 +16,6 @@ There are two types of graphs in Studio:
 * **Deployed graphs** are shared with other members of your organization. Create a deployed graph for every use case _except_ local development.
 * **Development graphs** (**dev graphs** for short) are only visible to you. Use them to help you iterate on your graph in your development environment.
 
-For **deployed graphs**, there are two types of visibility you can set on your graph.
-* **Visible to others by default** – this is the standard option. Your graph will be visible to all members of your organization in their graph list.
-* **Hidden from others unless granted access** – this options is available to graphs created in an organization with an Enterprise subscription. Your graph will only be visible to members you have explicitly invited from your Graph's Settings/Access page. You can change this preference at any time.
-
-
 ## Registering a schema
 
 You can register your schema to a Studio graph with one of the following methods:
@@ -33,7 +28,7 @@ You can register your schema to a Studio graph with one of the following methods
 After selecting an organization in Studio, click on a particular graph
 to view its schema, data, and settings. All of a Studio organization's members can access the data and settings for every graph that belongs to that organization.
 
-> Enterprise accounts can set [member roles](./members/#member-roles) to configure access for individual members of their organization.
+> Enterprise accounts can set [member roles](./members/#organization-wide-member-roles) to configure access for individual members of their organization.
 
 ### Exploring your schema
 
@@ -48,6 +43,12 @@ The History view in Apollo Studio lets you view the timeline of changes made to 
 <img src="../img//schema-history.jpg" class="screenshot" alt="Studio History view" width="400"></img>
 
 **Only schema changes that you push to Studio are included in this timeline**, which is one of the most important reasons to [include schema registration in your continuous delivery pipeline](../schema/cli-registration/#registering-with-continuous-delivery).
+
+## Setting graph visibility (Enterprise only)
+
+By default, deployed graphs are visible to all members of your organization. If you have an Enterprise plan, you can set a deployed graph to instead be visible only to members you invite. 
+
+You can configure visibility and invite members from the Access tab of your graph's Settings page.
 
 ## Managing variants
 
@@ -65,13 +66,11 @@ You can configure Apollo Server to associate the metrics it sends to Apollo Stud
 
 > Make sure you associate metrics with the correct variant! Otherwise, metrics from your staging and test environments will be included in reports for your production graph.
 
-### Protected variants
+### Protected variants (Enterprise only)
 
-If your graph is in an organization with an Enterprise subscription, you can specify particular variants to be come **protected variants**. This means that members of  your org who might otherwise have permission to push schema and change configurations for your graphs may not have that permission for a protected variant.
+If you have an Enterprise plan, you can designate particular variants of a graph as **protected variants**. Members of your organization with the [`Contributor` role](/org/members/#organization-wide-member-roles) _cannot_ push schema updates to a protected variant. Only members with the `Organization Admin` or `Graph Admin` role can do so. `Contributor` members still have read access to protected variants.
 
-This specifically applies to the [Contributor role](/org/members/#member-roles-in-organizations). Contributors will become read-only users (with the same permissions as observers) for protected variants, while their contributor permission remains for all unprotected variants. Effectively, contributors will not be able to push new schemas to protected variants.
-
-Graph admins and organization admins remain administrative users who still have permission to change everything about a graph. Observers and Consumers remain read-only users.
+Configure protected variants from the Access tab of your graph's Settings page.
 
 ## Transferring graph ownership
 

--- a/studio-docs/source/org/graphs.mdx
+++ b/studio-docs/source/org/graphs.mdx
@@ -9,12 +9,17 @@ A **graph** in Apollo Studio represents a connected data graph in your organizat
 
 To create a graph in [Apollo Studio](https://studio.apollographql.com/), first select the Studio organization that the graph will belong to. Then click **New Graph** in the upper right and proceed through the creation flow:
 
-<img class="screenshot" src="../img/graph-creation.jpg" width="500" />
+<img class="screenshot" src="../img/graph-creation.jpg" width="500" style="margin-bottom: 20px;" />
 
 There are two types of graphs in Studio:
 
 * **Deployed graphs** are shared with other members of your organization. Create a deployed graph for every use case _except_ local development.
 * **Development graphs** (**dev graphs** for short) are only visible to you. Use them to help you iterate on your graph in your development environment.
+
+For **deployed graphs**, there are two types of visibility you can set on your graph.
+* **Visible to others by default** – this is the standard option. Your graph will be visible to all members of your organization in their graph list.
+* **Hidden from others unless granted access** – this options is available to graphs created in an organization with an Enterprise subscription. Your graph will only be visible to members you have explicitly invited from your Graph's Settings/Access page. You can change this preference at any time.
+
 
 ## Registering a schema
 

--- a/studio-docs/source/org/graphs.mdx
+++ b/studio-docs/source/org/graphs.mdx
@@ -70,12 +70,14 @@ You can configure Apollo Server to associate the metrics it sends to Apollo Stud
 
 ### Protected variants (Enterprise only)
 
-If you have an Enterprise plan, you can designate particular variants of a graph as **protected variants**. Members of your organization with the [`Contributor` role](/org/members/#organization-wide-member-roles) will have reduced permission for protected variants in your graph in the following ways:
-- They _cannot_ push schema updates to a protected variant. Only members with the `Organization Admin` or `Graph Admin` role can do so. `Contributor` members still have read access to protected variants.
-- The will not be able to manage settings for the Explorer, like setting its URL.
-- Graph API Keys with the `Contributor` permission will not be able to report usage metrics to your graph. Only `Graph Admin` keys will be able to report usage.
+If you have an Enterprise plan, you can designate particular variants of a graph as **protected variants**. Making a variant protected specifically affects the ability of users with the [`Contributor` role](/org/members/#organization-wide-member-roles) to make certain changes to the variant:
+- `Contributor`s _cannot_ push schema updates to a protected variant.
+- `Contributors` _cannot_ manage Explorer-related settings for a protected variant, like setting its URL.
+- Graph API Keys with the `Contributor` permission will not be able to report usage metrics to your graph.
 
-You can configure protected variants from the Access tab of your graph's Settings page.
+These are the only operations (other than creating new protected variants and creating new graphs) that can be performed by `Contributor`s and not by `Observer`s, so one way of thinking of protected variants are that they are variants where `Contributor`s are treated as `Observer`s.
+
+`Graph Admins` and `Org Admins` can configure whether a variant is protected from the Access tab of the graph's Settings page.
 
 ## Transferring graph ownership
 

--- a/studio-docs/source/org/graphs.mdx
+++ b/studio-docs/source/org/graphs.mdx
@@ -48,7 +48,9 @@ The History view in Apollo Studio lets you view the timeline of changes made to 
 
 By default, deployed graphs are visible to all members of your organization. If you have an Enterprise plan, you can set a deployed graph to instead be visible only to members you invite. 
 
-You can configure visibility and invite members from the Access tab of your graph's Settings page.
+You can configure visibility and grant your organization's members explicit access to your graph from the Access tab of your graph's Settings page.
+
+`Organization Admins` can see all graphs in your organization though, regardless of if they are **visible** or **hidden**.
 
 ## Managing variants
 
@@ -68,9 +70,12 @@ You can configure Apollo Server to associate the metrics it sends to Apollo Stud
 
 ### Protected variants (Enterprise only)
 
-If you have an Enterprise plan, you can designate particular variants of a graph as **protected variants**. Members of your organization with the [`Contributor` role](/org/members/#organization-wide-member-roles) _cannot_ push schema updates to a protected variant. Only members with the `Organization Admin` or `Graph Admin` role can do so. `Contributor` members still have read access to protected variants.
+If you have an Enterprise plan, you can designate particular variants of a graph as **protected variants**. Members of your organization with the [`Contributor` role](/org/members/#organization-wide-member-roles) will have reduced permission for protected variants in your graph in the following ways:
+- They _cannot_ push schema updates to a protected variant. Only members with the `Organization Admin` or `Graph Admin` role can do so. `Contributor` members still have read access to protected variants.
+- The will not be able to manage settings for the Explorer, like setting its URL.
+- Graph API Keys with the `Contributor` permission will not be able to report usage metrics to your graph. Only `Graph Admin` keys will be able to report usage.
 
-Configure protected variants from the Access tab of your graph's Settings page.
+You can configure protected variants from the Access tab of your graph's Settings page.
 
 ## Transferring graph ownership
 

--- a/studio-docs/source/org/graphs.mdx
+++ b/studio-docs/source/org/graphs.mdx
@@ -65,6 +65,14 @@ You can configure Apollo Server to associate the metrics it sends to Apollo Stud
 
 > Make sure you associate metrics with the correct variant! Otherwise, metrics from your staging and test environments will be included in reports for your production graph.
 
+### Protected variants
+
+If your graph is in an organization with an Enterprise subscription, you can specify particular variants to be come **protected variants**. This means that members of  your org who might otherwise have permission to push schema and change configurations for your graphs may not have that permission for a protected variant.
+
+This specifically applies to the [Contributor role](/org/members/#member-roles-in-organizations). Contributors will become read-only users (with the same permissions as observers) for protected variants, while their contributor permission remains for all unprotected variants. Effectively, contributors will not be able to push new schemas to protected variants.
+
+Graph admins and organization admins remain administrative users who still have permission to change everything about a graph. Observers and Consumers remain read-only users.
+
 ## Transferring graph ownership
 
 You can transfer a graph to a different Studio organization you belong to

--- a/studio-docs/source/org/members.mdx
+++ b/studio-docs/source/org/members.mdx
@@ -73,7 +73,7 @@ When `Contributors` in an organization create a new graph, they are automaticall
 > - We significantly reduced the permissions of the `Contributor` role, making it much closer to `Observer` plus the ability to perform a small set of write operations on protected variants.
 > - We added the `Graph Admin` role. This role is nearly identical to the former `Contributor` role; as part of the transition, we changed all existing `Contributors` to `Graph Admins`. The only difference between the old `Contributor` role and the new `Graph Admin` role is that `Graph Admins` can delete graphs (and manage graph overrides, a new feature released simultaneously).
 
-> Currently, graph usage metrics and traces are not displayed to `Consumer`s via the Studio web app but they are not blocked at the API layer. We intend to remove this capability from `Consumer`s, but for the time being you should und erstand that `Consumer`s are not fully prevented from accessing these metrics and traces.
+> Currently, graph usage metrics and traces are not displayed to `Consumer`s via the Studio web app but they are not blocked at the API layer. We intend to remove this capability from `Consumer`s, but for the time being you should understand that `Consumer`s are not fully prevented from accessing these metrics and traces.
 
 ### Billing Managers
 `Billing Managers` cannot see or manage graphs in their organizations, but they can:

--- a/studio-docs/source/org/members.mdx
+++ b/studio-docs/source/org/members.mdx
@@ -9,7 +9,7 @@ A Studio organization can have any number of members, and each member can be ass
 
 > **Member roles are available for organizations with an Enterprise plan.**
 >
-> Apollo Support can also grant access to the Billing Manager role for Team accounts on request. Please contact **support@apollographql.com** for more information.
+> Apollo Support can also grant complimentary access to the Billing Manager role for Team accounts on request. Please contact **support@apollographql.com** for more information.
 >
 > If you're using member roles, [please let us know what you think!](https://docs.google.com/forms/d/10C4_ETX5Xb60RfnJjBC2xBVK9gjr6A644AYKA-27T-E/viewform) Your feedback will help us improve the feature before we roll it out to all organizations.
 >
@@ -36,11 +36,13 @@ You can override a member's organization-wide role for individual graphs. For ex
 
 Members with the `Graph Admin` or `Organization Admin` role can assign graph-specific roles from the Access tab of the graph's Settings page.
 
+If a graph is made [hidden](./graphs/#setting-graph-visibility-enterprise-only), then only users with explicit overrides (as well as `Org Admins`) can see the graph.
+
+`Graph Admins` and `Org Admins` have exactly the same permissions on graphs, so you can only grant a `Graph Admin` override, not an (equivalent) `Org Admin` override.
+
 When `Contributors` in an organization create a new graph, they are automatically granted the `Graph Admin` role on that graph.
 
 ## Role permissions
-
-> In January 2021, we added the `Graph Admin` role and reduced permissions for members with the `Contributor` role.
 
 | Action                                                          | Org Admin | Graph Admin | Contributor | Observer | Consumer |
 | :-------------------------------------------------------------- | :-------: | :---------: | :---------: | :------: | :------: |
@@ -49,33 +51,61 @@ When `Contributors` in an organization create a new graph, they are automaticall
 | View and edit billing information                               |     ✓     |             |             |          |          |
 | Manage organization configuration (name, avatar, etc.)          |     ✓     |             |             |          |          |
 | Delete the organization                                         |     ✓     |             |             |          |          |
-| Manage which users have access to the graph                     |     ✓     |      ✓      |             |          |          |
+| Manage which users have access to graphs                        |     ✓     |      ✓      |             |          |          |
 | Manage graph integrations (Datadog, Slack, etc.)                |     ✓     |      ✓      |             |          |          |
 | View and manage graph API keys                                  |     ✓     |      ✓      |             |          |          |
 | Modify schema checks configuration                              |     ✓     |      ✓      |             |          |          |
-| Delete graphs                                                   |     ✓     |      ✓      |             |          |          |
+| Delete and rename graphs                                        |     ✓     |      ✓      |             |          |          |
+| Create new variants                                             |     ✓     |      ✓      |  Non-protected variants only      |          |          |
+| Push schemas to a graph                                         |     ✓     |      ✓      |  Non-protected variants only      |          |          |
+| Manage Explorer settings (URL, etc)                             |     ✓     |      ✓      |  Non-protected variants only      |          |          |
 | Create [Deployed Graphs](/org/graphs/)                          |     ✓     |      ✓      |      ✓      |          |          |
-| Create [Development Graphs](/dev-graphs/)                       |     ✓     |      ✓      |      ✓      |    ✓     |     ✓    |
-| Push schemas to a non-protected variant                         |     ✓     |      ✓      |      ✓      |          |          |
-| Push schemas to a [protected variant](./graphs/#protected-variants-enterprise-only) |     ✓     |      ✓      |            |          |          |
 | Run schema checks                                               |     ✓     |      ✓      |      ✓      |    ✓     |          |
 | See the schemas of implementing services in federated graphs    |     ✓     |      ✓      |      ✓      |    ✓     |          |
-| View graph usage metrics                                        |     ✓     |      ✓      |      ✓      |    ✓     |          |
+| View graph usage metrics and traces                             |     ✓     |      ✓      |      ✓      |    ✓     |          |
+| Create [Development Graphs](/dev-graphs/)                       |     ✓     |      ✓      |      ✓      |    ✓     |     ✓    |
 | View graph schemas and changelogs                               |     ✓     |      ✓      |      ✓      |    ✓     |    ✓     |
 | Query graphs with the Explorer                                  |     ✓     |      ✓      |      ✓      |    ✓     |    ✓     |
+
+
+> In January 2021, we made three changes to our role structure:
+> - We removed the ability of `Observers` to view integration settings, as some of these settings contain sensitive information.
+> - We significantly reduced the permissions of the `Contributor` role, making it much closer to `Observer` plus the ability to perform a small set of write operations on protected variants.
+> - We added the `Graph Admin` role. This role is nearly identical to the former `Contributor` role; as part of the transition, we changed all existing `Contributors` to `Graph Admins`. The only difference between the old `Contributor` role and the new `Graph Admin` role is that `Graph Admins` can delete graphs (and manage graph overrides, a new feature released simultaneously).
+
+> Currently, graph usage metrics and traces are not displayed to `Consumer`s via the Studio web app but they are not blocked at the API layer. We intend to remove this capability from `Consumer`s, but for the time being you should und erstand that `Consumer`s are not fully prevented from accessing these metrics and traces.
 
 ### Billing Managers
 `Billing Managers` cannot see or manage graphs in their organizations, but they can:
 - Remove members from the organization
-- View and edit billing information
+- View and edit billing information (including changing the billing plan)
 - Manage organization configuration (name, avatar, etc.)
 
-Notable, `Billing Managers` cannot invite new members to their organizations.
+Notably, `Billing Managers` cannot invite new members to the organization or update roles.
 
 ### Dev Graphs
 
-It is worth noting that [Development Graphs](/dev-graphs/) take a special permission in our system.
-Any user, regarldess their permission, can create a dev graph and act as the `Graph Admin` for it. Dev graphs are private to the users who creat them.
+[Development Graphs](/dev-graphs/) work specially in our permissions system.
+Any user in an organization (even a `Consumer`) can create a dev graph and act as the `Graph Admin` for it. Dev graphs are private to the users who create them: even `Org Admins` cannot view them, and they cannot currently be shared with other users via overrides.
+
+## Graph key roles
+
+Each [graph API key](../api-keys/) also has a corresponding member role. Like graph overrides, this role may be `Graph Admin` (the default), `Contributor`, `Observer`, or `Consumer`. Graph API keys may only act on the graph associated with the key, and cannot perform any operations on organizations or users. They are otherwise equivalent in power to a user with the same role on the graph. For example, `Consumer` keys can be used to fetch the graph schema, and `Graph Admin` keys can be used to manage integrations.
+
+There are a few operations that are not listed in the chart above because they are *only* supported by graph API keys, not personal API keys for users in the graph's organization. These are primarily operations that are performed by your GraphQL server. They are:
+
+- Reporting usage (traces and performance metrics). This requires a `Graph Admin` key, or a `Contributor` key if the variant is not protected.
+- [Registering operations](../operation-registry/). This requires a `Graph Admin` key.
+
+Before January 2021, graph keys did not have roles. Keys created before that date (which are shown as `Legacy Admin` keys) can perform the following operations:
+- Create new variants
+- Run schema checks
+- View and manage graph API keys
+- Push schemas to a graph
+- See the schemas of implementing services in federated graphs
+- View graph schemas and changelogs
+- Modify schema checks configuration
+
 
 ## Inviting members
 

--- a/studio-docs/source/org/members.mdx
+++ b/studio-docs/source/org/members.mdx
@@ -68,12 +68,12 @@ When `Contributors` in an organization create a new graph, they are automaticall
 | Query graphs with the Explorer                                  |     ✓     |      ✓      |      ✓      |    ✓     |    ✓     |
 
 
+> Currently, graph usage metrics and traces are not displayed to `Consumer`s via the Studio web app but they are not blocked at the API layer. We intend to remove this capability from `Consumer`s, but for the time being you should understand that `Consumer`s are not fully prevented from accessing these metrics and traces.
+
 > In January 2021, we made three changes to our role structure:
 > - We removed the ability of `Observers` to view integration settings, as some of these settings contain sensitive information.
 > - We significantly reduced the permissions of the `Contributor` role, making it much closer to `Observer` plus the ability to perform a small set of write operations on protected variants.
 > - We added the `Graph Admin` role. This role is nearly identical to the former `Contributor` role; as part of the transition, we changed all existing `Contributors` to `Graph Admins`. The only difference between the old `Contributor` role and the new `Graph Admin` role is that `Graph Admins` can delete graphs (and manage graph overrides, a new feature released simultaneously).
-
-> Currently, graph usage metrics and traces are not displayed to `Consumer`s via the Studio web app but they are not blocked at the API layer. We intend to remove this capability from `Consumer`s, but for the time being you should understand that `Consumer`s are not fully prevented from accessing these metrics and traces.
 
 ### Billing Managers
 `Billing Managers` cannot see or manage graphs in their organizations, but they can:
@@ -85,8 +85,8 @@ Notably, `Billing Managers` cannot invite new members to the organization or upd
 
 ### Dev Graphs
 
-[Development Graphs](/dev-graphs/) work specially in our permissions system.
-Any user in an organization (even a `Consumer`) can create a dev graph and act as the `Graph Admin` for it. Dev graphs are private to the users who create them: even `Org Admins` cannot view them, and they cannot currently be shared with other users via overrides.
+[Development Graphs](/dev-graphs/) are a special case in our permissions system.
+Any user in an organization (even a `Consumer`) can create a dev graph and act as the `Graph Admin` for it. Dev graphs are private to the users who create them: even `Org Admins` cannot view them, and they cannot currently be shared with other users.
 
 ## Graph key roles
 

--- a/studio-docs/source/org/members.mdx
+++ b/studio-docs/source/org/members.mdx
@@ -72,7 +72,7 @@ When `Contributors` in an organization create a new graph, they are automaticall
 
 > In January 2021, we made three changes to our role structure:
 > - We removed the ability of `Observers` to view integration settings, as some of these settings contain sensitive information.
-> - We significantly reduced the permissions of the `Contributor` role, making it much closer to `Observer` plus the ability to perform a small set of write operations on protected variants.
+> - We significantly reduced the permissions of the `Contributor` role, making it much closer to `Observer` plus the ability to perform a small set of write operations on non-protected variants.
 > - We added the `Graph Admin` role. This role is nearly identical to the former `Contributor` role; as part of the transition, we changed all existing `Contributors` to `Graph Admins`. The only difference between the old `Contributor` role and the new `Graph Admin` role is that `Graph Admins` can delete graphs (and manage graph overrides, a new feature released simultaneously).
 
 ### Billing Managers

--- a/studio-docs/source/org/members.mdx
+++ b/studio-docs/source/org/members.mdx
@@ -5,11 +5,11 @@ sidebar_title: Members, roles, and permissions
 
 A Studio organization can have any number of members, and each member can be assigned a **role** that defines their capabilities within the organization.
 
-## Member roles in organizations
+## Organization-wide member roles
 
-> **Member roles are available for Enterprise accounts.**
+> **Member roles are available for organizations with an Enterprise plan.**
 >
-> Apollo Support can also grant access to the Billing Manager role for Team accounts on request. Please contact support@apollographql.com for more information.
+> Apollo Support can also grant access to the Billing Manager role for Team accounts on request. Please contact **support@apollographql.com** for more information.
 >
 > If you're using member roles, [please let us know what you think!](https://docs.google.com/forms/d/10C4_ETX5Xb60RfnJjBC2xBVK9gjr6A644AYKA-27T-E/viewform) Your feedback will help us improve the feature before we roll it out to all organizations.
 >
@@ -21,16 +21,24 @@ Each organization member has one of the following roles:
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `Organization Admin` | Has management access to the entire organization, including its members, graphs, and configuration.                                                                                                                |
 | `Graph Admin`        | Has management access to the organization's graphs, but not to members or organization-level configuration. Intended for developers who are considered admins to the graph.                                        |
-| `Contributor`        | Can push new schemas to graphs, but cannot configure graph settings or integrations. Intended for back-end developers who are authorized to make changes to graphs.                                                |
+| `Contributor`        | Can push new schemas to graphs, but cannot configure graph settings or integrations. Intended for back-end developers who are authorized to make changes to graphs. _Cannot_ push schema changes to [protected variants](./graphs/#protected-variants-enterprise-only).                                               |
 | `Observer`           | Has view-only access to the organization's graph data, such as schemas and metrics. Can also execute queries in the Explorer. Intended for back-end developers who are _not_ authorized to make changes to graphs. |
 | `Consumer`           | Has view-only access to the organization's graph _schemas_, but not metrics. Can also execute queries in the Explorer. Intended for application developers building clients against a graph.                       |
 | `Billing Manager`    | Has management access to organization-level configuration and billing. Can also remove members (but not invite them). No access to graphs.                                                                         |
 
-> On XX/YY/ZZ, we introduced the **Graph Admin** role and redefined the **Contributor** role to have fewer permissions. All members who were **Contributors** before that point were automatically reduced to updated Contributor role *with a lower permission set* unless otherwise discussed with your customer success manager.
+Only members with the `Organization Admin` role can assign roles to other members. You can see which role you have in a particular organization from your [user settings page](https://studio.apollographql.com/user-settings), or from the organization's Members tab.
 
-Only organization admins can assign roles to other members. You can see which role you have in a particular organization from your [user settings page](https://studio.apollographql.com/user-settings), or from that organization's Members tab.
+## Graph-specific member roles
 
-### Role permissions
+You can override a member's organization-wide role for individual graphs. For example, if a member has the `Observer` role in your organization, you can assign them the `Contributor` role for a graph that they need extra access to.
+
+> A member's graph-specific role must have _more_ permissions than their organization-wide role.
+
+Members with the `Graph Admin` or `Organization Admin` role can assign graph-specific roles from the Access tab of the graph's Settings page.
+
+## Role permissions
+
+> We recently added the `Graph Admin` role and reduced permissions for members with the `Contributor` role.
 
 | Action                                                 | Org Admin | Graph Admin | Billing Manager | Contributor | Observer | Consumer |
 | :----------------------------------------------------- | :-------: | :---------: | :-------------: | :---------: | :------: | :------: |
@@ -44,18 +52,11 @@ Only organization admins can assign roles to other members. You can see which ro
 | View and manage graph API keys                         |     ✓     |      ✓      |                 |             |          |          |
 | Modify schema checks configuration                     |     ✓     |      ✓      |                 |             |          |          |
 | Push schemas to your graph                             |     ✓     |      ✓      |                 |      ✓      |          |          |
+| Push schemas to a [protected variant](./graphs/#protected-variants-enterprise-only)                             |     ✓     |      ✓      |                 |            |          |          |
 | Run schema checks                                      |     ✓     |      ✓      |                 |      ✓      |    ✓     |          |
 | View graph usage metrics                               |     ✓     |      ✓      |                 |      ✓      |    ✓     |          |
 | View graph schemas and changelogs                      |     ✓     |      ✓      |                 |      ✓      |    ✓     |    ✓     |
 | Query graphs with the Explorer                         |     ✓     |      ✓      |                 |      ✓      |    ✓     |    ✓     |
-
-## Member roles for graphs
-
-For any graph in your organization, you can provide a single member with a **graph role override** that will replace the permissions allotted by their organization role.
-
-Graph admins and organization admins may set graph role overrides. Graph role overrides must strictly be *promotions* from the member's organization role; you cannot enforce a *permission downgrade* with a graph role override.
-
-You cannot set graph role overrides for organization admins. They will always be full admins unless you downgrade their role on the organization.
 
 ## Inviting members
 

--- a/studio-docs/source/org/members.mdx
+++ b/studio-docs/source/org/members.mdx
@@ -36,27 +36,46 @@ You can override a member's organization-wide role for individual graphs. For ex
 
 Members with the `Graph Admin` or `Organization Admin` role can assign graph-specific roles from the Access tab of the graph's Settings page.
 
+When `Contributors` in an organization create a new graph, they are automatically granted the `Graph Admin` role on that graph.
+
 ## Role permissions
 
-> We recently added the `Graph Admin` role and reduced permissions for members with the `Contributor` role.
+> In January 2021, we added the `Graph Admin` role and reduced permissions for members with the `Contributor` role.
 
-| Action                                                 | Org Admin | Graph Admin | Billing Manager | Contributor | Observer | Consumer |
-| :----------------------------------------------------- | :-------: | :---------: | :-------------: | :---------: | :------: | :------: |
-| Invite members                                         |     ✓     |             |                 |             |          |          |
-| Remove members                                         |     ✓     |             |        ✓        |             |          |          |
-| View and edit billing information                      |     ✓     |             |        ✓        |             |          |          |
-| Manage organization configuration (name, avatar, etc.) |     ✓     |             |        ✓        |             |          |          |
-| Delete graphs                                          |     ✓     |      ✓      |                 |             |          |          |
-| Create, rename graphs                                  |     ✓     |      ✓      |                 |             |          |          |
-| Manage graph integrations (Datadog, Slack, etc.)       |     ✓     |      ✓      |                 |             |          |          |
-| View and manage graph API keys                         |     ✓     |      ✓      |                 |             |          |          |
-| Modify schema checks configuration                     |     ✓     |      ✓      |                 |             |          |          |
-| Push schemas to your graph                             |     ✓     |      ✓      |                 |      ✓      |          |          |
-| Push schemas to a [protected variant](./graphs/#protected-variants-enterprise-only)                             |     ✓     |      ✓      |                 |            |          |          |
-| Run schema checks                                      |     ✓     |      ✓      |                 |      ✓      |    ✓     |          |
-| View graph usage metrics                               |     ✓     |      ✓      |                 |      ✓      |    ✓     |          |
-| View graph schemas and changelogs                      |     ✓     |      ✓      |                 |      ✓      |    ✓     |    ✓     |
-| Query graphs with the Explorer                         |     ✓     |      ✓      |                 |      ✓      |    ✓     |    ✓     |
+| Action                                                          | Org Admin | Graph Admin | Contributor | Observer | Consumer |
+| :-------------------------------------------------------------- | :-------: | :---------: | :---------: | :------: | :------: |
+| Invite members                                                  |     ✓     |             |             |          |          |
+| Remove members                                                  |     ✓     |             |             |          |          |
+| View and edit billing information                               |     ✓     |             |             |          |          |
+| Manage organization configuration (name, avatar, etc.)          |     ✓     |             |             |          |          |
+| Delete the organization                                         |     ✓     |             |             |          |          |
+| Manage which users have access to the graph                     |     ✓     |      ✓      |             |          |          |
+| Manage graph integrations (Datadog, Slack, etc.)                |     ✓     |      ✓      |             |          |          |
+| View and manage graph API keys                                  |     ✓     |      ✓      |             |          |          |
+| Modify schema checks configuration                              |     ✓     |      ✓      |             |          |          |
+| Delete graphs                                                   |     ✓     |      ✓      |             |          |          |
+| Create [Deployed Graphs](/org/graphs/)                          |     ✓     |      ✓      |      ✓      |          |          |
+| Create [Development Graphs](/dev-graphs/)                       |     ✓     |      ✓      |      ✓      |    ✓     |     ✓    |
+| Push schemas to a non-protected variant                         |     ✓     |      ✓      |      ✓      |          |          |
+| Push schemas to a [protected variant](./graphs/#protected-variants-enterprise-only) |     ✓     |      ✓      |            |          |          |
+| Run schema checks                                               |     ✓     |      ✓      |      ✓      |    ✓     |          |
+| See the schemas of implementing services in federated graphs    |     ✓     |      ✓      |      ✓      |    ✓     |          |
+| View graph usage metrics                                        |     ✓     |      ✓      |      ✓      |    ✓     |          |
+| View graph schemas and changelogs                               |     ✓     |      ✓      |      ✓      |    ✓     |    ✓     |
+| Query graphs with the Explorer                                  |     ✓     |      ✓      |      ✓      |    ✓     |    ✓     |
+
+### Billing Managers
+`Billing Managers` cannot see or manage graphs in their organizations, but they can:
+- Remove members from the organization
+- View and edit billing information
+- Manage organization configuration (name, avatar, etc.)
+
+Notable, `Billing Managers` cannot invite new members to their organizations.
+
+### Dev Graphs
+
+It is worth noting that [Development Graphs](/dev-graphs/) take a special permission in our system.
+Any user, regarldess their permission, can create a dev graph and act as the `Graph Admin` for it. Dev graphs are private to the users who creat them.
 
 ## Inviting members
 

--- a/studio-docs/source/org/members.mdx
+++ b/studio-docs/source/org/members.mdx
@@ -5,7 +5,7 @@ sidebar_title: Members, roles, and permissions
 
 A Studio organization can have any number of members, and each member can be assigned a **role** that defines their capabilities within the organization.
 
-## Member roles
+## Member roles in organizations
 
 > **Member roles are available for Enterprise accounts.**
 >
@@ -17,41 +17,52 @@ A Studio organization can have any number of members, and each member can be ass
 
 Each organization member has one of the following roles:
 
-| Name              | Description                                                                                                                                                                                                        |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Admin`           | Has management access to the entire organization, including its members, graphs, and configuration.                                                                                                                |
-| `Contributor`     | Has management access to the organization's graphs, but not to members or organization-level configuration. Intended for back-end developers who are authorized to make changes to graphs.                         |
-| `Observer`        | Has view-only access to the organization's graph data, such as schemas and metrics. Can also execute queries in the Explorer. Intended for back-end developers who are _not_ authorized to make changes to graphs. |
-| `Consumer`        | Has view-only access to the organization's graph _schemas_, but not metrics. Can also execute queries in the Explorer. Intended for application developers building clients against a graph.                       |
-| `Billing Manager` | Has management access to organization-level configuration and billing. Can also remove members (but not invite them). No access to graphs.                                                                         |
+| Name                 | Description                                                                                                                                                                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Organization Admin` | Has management access to the entire organization, including its members, graphs, and configuration.                                                                                                                |
+| `Graph Admin`        | Has management access to the organization's graphs, but not to members or organization-level configuration. Intended for developers who are considered admins to the graph.                                        |
+| `Contributor`        | Can push new schemas to graphs, but cannot configure graph settings or integrations. Intended for back-end developers who are authorized to make changes to graphs.                                                |
+| `Observer`           | Has view-only access to the organization's graph data, such as schemas and metrics. Can also execute queries in the Explorer. Intended for back-end developers who are _not_ authorized to make changes to graphs. |
+| `Consumer`           | Has view-only access to the organization's graph _schemas_, but not metrics. Can also execute queries in the Explorer. Intended for application developers building clients against a graph.                       |
+| `Billing Manager`    | Has management access to organization-level configuration and billing. Can also remove members (but not invite them). No access to graphs.                                                                         |
 
-Only admins can assign roles to other members. You can see which role you have in a particular organization from your [user settings page](https://studio.apollographql.com/user-settings), or from that organization's Members tab.
+> On XX/YY/ZZ, we introduced the **Graph Admin** role and redefined the **Contributor** role to have fewer permissions. All members who were **Contributors** before that point were automatically reduced to updated Contributor role *with a lower permission set* unless otherwise discussed with your customer success manager.
+
+Only organization admins can assign roles to other members. You can see which role you have in a particular organization from your [user settings page](https://studio.apollographql.com/user-settings), or from that organization's Members tab.
 
 ### Role permissions
 
-| Action                                                 | Admin | Billing Manager | Contributor | Observer | Consumer |
-| :----------------------------------------------------- | :---: | :-------------: | :---------: | :------: | :------: |
-| Invite members                                         |   ✓   |                 |             |          |          |
-| Remove members                                         |   ✓   |        ✓        |             |          |          |
-| View and edit billing information                      |   ✓   |        ✓        |             |          |          |
-| Manage organization configuration (name, avatar, etc.) |   ✓   |        ✓        |             |          |          |
-| Delete graphs                                          |   ✓   |                 |             |          |          |
-| Create, rename graphs                                  |   ✓   |                 |      ✓      |          |          |
-| Manage graph integrations (Datadog, Slack, etc.)       |   ✓   |                 |      ✓      |          |          |
-| View and manage graph API keys                         |   ✓   |                 |      ✓      |          |          |
-| Modify schema checks configuration                     |   ✓   |                 |      ✓      |          |          |
-| Push schemas to your graph                             |   ✓   |                 |      ✓      |          |          |
-| Run schema checks                                      |   ✓   |                 |      ✓      |    ✓     |          |
-| View graph usage metrics                               |   ✓   |                 |      ✓      |    ✓     |          |
-| View graph schemas and changelogs                      |   ✓   |                 |      ✓      |    ✓     |    ✓     |
-| Query graphs with the Explorer                         |   ✓   |                 |      ✓      |    ✓     |    ✓     |
+| Action                                                 | Org Admin | Graph Admin | Billing Manager | Contributor | Observer | Consumer |
+| :----------------------------------------------------- | :-------: | :---------: | :-------------: | :---------: | :------: | :------: |
+| Invite members                                         |     ✓     |             |                 |             |          |          |
+| Remove members                                         |     ✓     |             |        ✓        |             |          |          |
+| View and edit billing information                      |     ✓     |             |        ✓        |             |          |          |
+| Manage organization configuration (name, avatar, etc.) |     ✓     |             |        ✓        |             |          |          |
+| Delete graphs                                          |     ✓     |      ✓      |                 |             |          |          |
+| Create, rename graphs                                  |     ✓     |      ✓      |                 |             |          |          |
+| Manage graph integrations (Datadog, Slack, etc.)       |     ✓     |      ✓      |                 |             |          |          |
+| View and manage graph API keys                         |     ✓     |      ✓      |                 |             |          |          |
+| Modify schema checks configuration                     |     ✓     |      ✓      |                 |             |          |          |
+| Push schemas to your graph                             |     ✓     |      ✓      |                 |      ✓      |          |          |
+| Run schema checks                                      |     ✓     |      ✓      |                 |      ✓      |    ✓     |          |
+| View graph usage metrics                               |     ✓     |      ✓      |                 |      ✓      |    ✓     |          |
+| View graph schemas and changelogs                      |     ✓     |      ✓      |                 |      ✓      |    ✓     |    ✓     |
+| Query graphs with the Explorer                         |     ✓     |      ✓      |                 |      ✓      |    ✓     |    ✓     |
+
+## Member roles for graphs
+
+For any graph in your organization, you can provide a single member with a **graph role override** that will replace the permissions allotted by their organization role.
+
+Graph admins and organization admins may set graph role overrides. Graph role overrides must strictly be *promotions* from the member's organization role; you cannot enforce a *permission downgrade* with a graph role override.
+
+You cannot set graph role overrides for organization admins. They will always be full admins unless you downgrade their role on the organization.
 
 ## Inviting members
 
-[Admins](#member-roles-available-by-request) can invite individual members by email address from your organization's Members tab in [Apollo Studio](https://studio.apollographql.com). Admins can also create a persistent **invite link** from the organization's Settings tab, which can be used to invite any number of members. Using either method, an admin can specify which role a new member receives.
+**Organization admins** can invite individual members by email address from your organization's Members tab in [Apollo Studio](https://studio.apollographql.com). Organization admins can also create a persistent **invite link** from the organization's Settings tab, which can be used to invite any number of members. Using either method, an org admin can specify which role a new member receives.
 
 > **Do not share invite links publicly.** Anyone with the link can join your organization. If an invite link becomes compromised, an admin can replace or disable it from the Settings tab.
 
 ## Removing members
 
-Both [admins and billing managers](#member-roles-available-by-request) can remove members from your organization's Members tab in [Apollo Studio](https://studio.apollographql.com).
+Both **organization admins** and **billing managers** can remove members from your organization's Members tab in [Apollo Studio](https://studio.apollographql.com).

--- a/studio-docs/source/org/organizations.mdx
+++ b/studio-docs/source/org/organizations.mdx
@@ -3,11 +3,7 @@ title: Organizations
 sidebar_title: Organizations
 ---
 
-All data in Apollo Studio (GraphQL schemas, metrics, etc.) belongs to a particular organization. Every organization has one or more [members](./members/) who manage it and can access its associated data.
-
-> **Important**: Currently by default, all members of a Studio organization have full permissions for the organization, including the ability to delete graphs or transfer them out of the organization.
->
-> You can control which role each member in your organization has if your account is on an [Enterprise subscription](https://apollographql.com/pricing).
+All data in Apollo Studio (GraphQL schemas, metrics, etc.) belongs to a particular organization. Every organization has one or more [members](./members/) who manage it and can access its associated data. Enterprise organizations can also assign specific [roles](./members/#organization-wide-member-roles) to users in the organization.
 
 ## Creating an organization
 


### PR DESCRIPTION
Document the upcoming Studio feature to add support for graph roles & protected variants, outlined here: https://github.com/apollographql/apollo-studio-community/blob/main/preview-docs/GraphRoles.md.

We'll want to hold off on merging this PR until the feature ships, but I figured it would be good to stage and prepare all the same.