### PR TITLE
Fix typo under tutorials create your first graph

### DIFF
--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -27,7 +27,7 @@ In Apollo Studio, each **graph** is a distinct data graph with a corresponding G
 1. From your [Studio homepage](https://studio.apollographql.com), click **New Graph** in the upper right.
 2. Provide a name for your graph and set the **Graph type** to **Deployed**.
     > Earlier, we [created a private _development_ graph](./schema/#with-apollo-studio-recommended) with Studio. This time we're creating a _deployed_ graph, which is shared with other members of our organization.
-3. Click **Next**. A dialog appears instructing to you register your schema. We'll do that in the next step.
+3. Click **Next**. A dialog appears instructing you to register your schema. We'll do that in the next step.
 
 ## Connect your server
 


### PR DESCRIPTION
## Summary

Typo under Create your first graph in section 5 of the tutorial 

### Location

> - apollo/docs/source/tutorial/production.md