### PR TITLE
Add alt tags to Federated graphs in Studio article

### DIFF
--- a/docs/source/intro/benefits.md
+++ b/docs/source/intro/benefits.md
@@ -89,13 +89,13 @@ Apollo provides a cloud-hosted collection of tools that help you measure your gr
 
 After registering your GraphQL schema, you can use Studio's **Explorer tab** to inspect all of its types and fields. You can also build and run queries against your running server:
 
-<img src="../img/explorer-tab.jpg" alt="Studio Explorer tab" class="screenshot"></img>
+<img src="../img/explorer-tab.jpg" alt="Studio Explorer tab" class="screenshot" />
 
 ### Apollo Client DevTools
 
 The Apollo Client DevTools extension for [Chrome](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/apollo-developer-tools/) enables you to inspect your Apollo Client cache, track active queries, and view mutations. It also includes [GraphiQL](https://github.com/graphql/graphiql), an IDE that helps you test queries while you're working on front-end code.
 
-<img src="../assets/dev-tools.png" alt="Apollo DevTools" class="screenshot"></img>
+<img src="../assets/dev-tools.png" alt="Apollo DevTools" class="screenshot" />
 
 ## Production readiness
 

--- a/docs/source/intro/platform.md
+++ b/docs/source/intro/platform.md
@@ -63,11 +63,11 @@ The Apollo [schema registry](https://www.apollographql.com/docs/studio/schema-re
 
 * A powerful **schema explorer** that helps your team build and run queries against your registered schema:
 
-    <img src="../img/explorer-tab.jpg" alt="Studio Explorer tab" class="screenshot"></img>
+    <img src="../img/explorer-tab.jpg" alt="Studio Explorer tab" class="screenshot" />
 
 * [Metrics reporting](https://www.apollographql.com/docs/studio/setup-analytics/) for up to the last 24 hours:
 
-    <img src="../img/operations-tab.jpg" alt="Studio Explorer tab" class="screenshot"></img>
+    <img src="../img/operations-tab.jpg" alt="Studio Explorer tab" class="screenshot" />
 
 * Team collaboration via [organizations](https://www.apollographql.com/docs/studio/org/organizations/)
 * [Slack notifications](https://www.apollographql.com/docs/studio/slack-integration/) for schema changes and daily metrics reports

--- a/docs/source/tutorial/client.mdx
+++ b/docs/source/tutorial/client.mdx
@@ -11,7 +11,7 @@ Time to accomplish: _10 Minutes_
 
 The remaining chapters of this tutorial walk through building our application frontend, which uses Apollo Client to communicate with the GraphQL server we just built:
 
-  <img src="../images/space-explorer.png" alt="Space explorer" width="400"></img>
+  <img src="../images/space-explorer.png" alt="Space explorer" width="400" />
 
 **Apollo Client** is a comprehensive state management library for JavaScript. It enables you to use GraphQL to manage both local and remote data. Apollo Client is view-layer agnostic, so you can use it with React, Vue, Angular, or even vanilla JS.
 

--- a/docs/source/tutorial/production.md
+++ b/docs/source/tutorial/production.md
@@ -35,7 +35,7 @@ Apollo Server can communicate directly with Apollo Studio to register its schema
 
 From your [Studio homepage](https://studio.apollographql.com), click your newly created graph. This displays the same dialog that appeared after you created it:
 
-<img src="../img/register-schema.png" class="screenshot" width="600"></img>
+<img src="../img/register-schema.png" class="screenshot" width="600" />
 
 Copy all of the environment variable definitions in the block at the bottom of the dialog (the value of `APOLLO_KEY` is your graph API key).
 
@@ -75,13 +75,13 @@ Connecting your server to Apollo Studio activates a variety of powerful features
 
 As shown [earlier in the tutorial](./schema/#explore-your-schema) the Apollo Studio Explorer provides a comprehensive view into your schema, including all documentation strings you include in it. Use it to build queries and execute them on your server.
 
-<img src="../img/explorer-tab.jpg" alt="Studio Explorer tab" class="screenshot" /></img>
+<img src="../img/explorer-tab.jpg" alt="Studio Explorer tab" class="screenshot" />
 
 ### Schema history
 
 Open the **History** tab to view a full revision history of the schema versions your server pushes over time:
 
-<img src="../img/schema-history/schema-history.jpg" class="screenshot" width="400"></img>
+<img src="../img/schema-history/schema-history.jpg" class="screenshot" width="400" />
 
 This history helps you identify exactly when a particular type or field was added or removed, which is crucial when diagnosing an issue.
 
@@ -93,7 +93,7 @@ Apollo Server pushes metrics data to Studio for each GraphQL operation it execut
 
 Open the **Operations** tab to view performance data based on the last 24 hours of your server's operation traces:
 
-<img src="../img/operations-tab.jpg" alt="Studio Explorer tab" class="screenshot"></img>
+<img src="../img/operations-tab.jpg" alt="Studio Explorer tab" class="screenshot" />
 
 > Organizations with a paid Studio plan can view metrics for the last 90 days or more, depending on the plan.  For more information on paid Studio features, see the [Studio documentation](https://www.apollographql.com/docs/studio/).
 

--- a/studio-docs/source/check-configurations.mdx
+++ b/studio-docs/source/check-configurations.mdx
@@ -12,7 +12,7 @@ After you [enable schema checks](./schema-checks/) for your graph, you can custo
 
 In [Apollo Studio](https://studio.apollographql.com), you can configure default rules that are applied to every executed schema check. You define these rules from the Configuration tab of your graph's Checks page:
 
-<img class="screenshot" src="./img/check-configurations/check-configuration-page.png" alt="Check configuration page in Apollo Studio"></img>
+<img class="screenshot" src="./img/check-configurations/check-configuration-page.png" alt="Check configuration page in Apollo Studio" />
 
 ### Configuration options
 
@@ -20,7 +20,7 @@ In [Apollo Studio](https://studio.apollographql.com), you can configure default 
 * **Operation count threshold**: _Exclude_ all operations that were executed fewer than this number of times within the specified **time range**.
 * **Variants**: _Include_ all distinct operations that were executed against each selected variant of your graph. The default value is "Base variant" (i.e., whichever variant schema checks are being run against).
 * **Client exclusions**: _Exclude_ all operations that were executed by particular clients, such as clients used exclusively for development and testing.
-    <img class="screenshot" src="./img/check-configurations/excluded-clients.png" alt="Excluded clients configuration in Apollo Studio"></img>
+    <img class="screenshot" src="./img/check-configurations/excluded-clients.png" alt="Excluded clients configuration in Apollo Studio" />
 
 ## Using the Apollo CLI
 

--- a/studio-docs/source/daily-reports.md
+++ b/studio-docs/source/daily-reports.md
@@ -5,7 +5,7 @@ sidebar_title: Daily reports
 
 You can [configure Apollo Studio](./notification-setup/) to send your team a daily summary of your graph's activity over the last 24 hours:
 
-<img src="./img/integrations/slack-report.png" width="400" alt="Slack daily report" class="screenshot"></img>
+<img src="./img/integrations/slack-report.png" width="400" alt="Slack daily report" class="screenshot" />
 
 When you configure daily reports, you can specify what time you want to receive them each day.
 

--- a/studio-docs/source/datadog-integration.md
+++ b/studio-docs/source/datadog-integration.md
@@ -11,13 +11,13 @@ To integrate with Datadog, you provide your Datadog API key and region to Studio
 
 1. Go to your [Datadog Integrations page](https://app.datadoghq.com/account/settings) and select **Apollo** from the list:
 
-    <img src="./img/datadog/integration-tile.png" alt="Datadog integration tile" class="screenshot">
+    <img src="./img/datadog/integration-tile.png" alt="Datadog integration tile" class="screenshot" />
 
     Then go to the Configuration tab and click **Install Integration** at the bottom.
 
 2. Go to your [Datadog APIs page](https://app.datadoghq.com/account/settings#api) and create an API key:
 
-    <img src="./img/datadog/api-key.png" alt="Datadog API key list" class="screenshot">
+    <img src="./img/datadog/api-key.png" alt="Datadog API key list" class="screenshot" />
 
 3. Determine your Datadog API region by looking at your browser's address bar:
 
@@ -26,11 +26,11 @@ To integrate with Datadog, you provide your Datadog API key and region to Studio
 
 4. In Studio, go to your graph's Integrations page:
 
-    <img src="./img/datadog/settings-link.png" alt="Studio Integrations page" class="screenshot">
+    <img src="./img/datadog/settings-link.png" alt="Studio Integrations page" class="screenshot" />
 
 5. In the Datadog Forwarding section, click **Configure**. Provide your API key and region, then click **Enable**.
 
-    <img src="./img/datadog/settings-toggle.png" alt="Datadog configuration dialog" class="screenshot" width="500">
+    <img src="./img/datadog/settings-toggle.png" alt="Datadog configuration dialog" class="screenshot" width="500" />
 
     You can use the same Datadog API key for all of your graphs, because all forwarded metrics are tagged with the corresponding graph's ID (`graph:<graph-id>`).
 
@@ -72,7 +72,7 @@ In the [Datadog metrics explorer](https://app.datadoghq.com/metric/explorer):
 
 At Apollo, we use Studio to monitor Studio itself, so this graph for us looks like the following:
 
-<img src="./img/datadog/datadog.png" alt="p95 latency graph" class="screenshot">
+<img src="./img/datadog/datadog.png" alt="p95 latency graph" class="screenshot" />
 
 To generate more advanced reports, open up a [Datadog notebook](https://app.datadoghq.com/notebook).
 

--- a/studio-docs/source/federated-graphs.mdx
+++ b/studio-docs/source/federated-graphs.mdx
@@ -26,15 +26,15 @@ Apollo Studio provides tools to help multiple teams collaborate on a federated g
 
 The **Schema > Reference** tab in Studio displays a table of your federated schema’s types and fields. This table includes a Subgraph column:
 
-<img class="screenshot" src="./img/federated-graphs/schema-reference-type-row-with-subgraph-column.jpg" width="736" />
+<img class="screenshot" src="./img/federated-graphs/schema-reference-type-row-with-subgraph-column.jpg" alt="Studio screenshot of Schema Reference, closeup of type row showing subgraph column" width="736" />
 
 Clicking the subgraph link for a type or field takes you to the line in the subgraph schema where it's defined:
 
-<img class="screenshot" src="./img/federated-graphs/type-definition-in-subgraph-sdl.jpg" width="700" />
+<img class="screenshot" src="./img/federated-graphs/type-definition-in-subgraph-sdl.jpg" alt="Studio screenshot of Schema SDL, closeup of type definition in subgraph schema" width="700" />
 
 If you're using [the `@contact` directive](#defining-subgraph-contact-information) to specify owner contact information for your subgraphs, hovering over a subgraph name displays its contact information, enabling you to follow up with the appropriate team:
 
-<img class="screenshot" src="./img/federated-graphs/schema-reference-type-row-showing-subgraph-contact-directive-tooltip.jpg" width="736" />
+<img class="screenshot" src="./img/federated-graphs/schema-reference-type-row-showing-subgraph-contact-directive-tooltip.jpg" alt="Studio screenshot showing subgraph contact tooltip in Schema Reference subgraph column" width="736" />
 
 ## Viewing subgraph SDL
 
@@ -51,7 +51,7 @@ From this tab you can:
 
 You can use the `@contact` directive to specify contact information for a particular subgraph, such as a name and URL. This information is visible in Studio, which helps your organization members find who to contact for assistance with a particular type or field:
 
-<img class="screenshot" src="./img/federated-graphs/subgraph-contact-info-on-sdl-closeup.jpg" width="424" />
+<img class="screenshot" src="./img/federated-graphs/subgraph-contact-info-on-sdl-closeup.jpg" alt="Studio screenshot showing use of contact directive info as metadata in the Schema SDL view" width="424" />
 
 ### Adding the `@contact` directive to your subgraph
 
@@ -112,11 +112,11 @@ Note that the `schema` object can’t be empty, so you need to add the `query` f
 
 After you register a subgraph schema with the `@contact` directive, the contact information is included in the metadata shown in Studio’s **Schema > SDL** tab:
 
-<img class="screenshot" src="./img/federated-graphs/subgraph-contact-info-on-sdl-closeup.jpg" width="424" />
+<img class="screenshot" src="./img/federated-graphs/subgraph-contact-info-on-sdl-closeup.jpg" alt="Studio screenshot showing use of contact directive info as metadata in the Schema SDL view" width="424" />
 
 In the **Schema > Reference** tab, you’ll also see a contact card when you hover over the subgraph link of a type or field:
 
-<img class="screenshot" src="./img/federated-graphs/schema-reference-contact-directive-tooltip-closeup.jpg" width="388" />
+<img class="screenshot" src="./img/federated-graphs/schema-reference-contact-directive-tooltip-closeup.jpg" alt="Studio screenshot showing subgraph contact tooltip in Schema Reference subgraph column" width="388" />
 
 ## Federation support in the Explorer
 
@@ -128,8 +128,8 @@ The [Apollo Studio Explorer](./explorer/) provides enhanced support for working 
 
 Studio displays a **Federated** label next to the name of a federated graph. If a federated graph has composition errors, you can click the label to view the errors that must be resolved before composition can succeed.
 
-<img class="screenshot" src="./img/federated-graphs/federated-graph-label-composition-error-state.jpg" width="426" />
+<img class="screenshot" src="./img/federated-graphs/federated-graph-label-composition-error-state.jpg" alt="Studio screenshot showing the Federated graph label in an error state" width="426" />
 
-<img class="screenshot" src="./img/federated-graphs/federated-graph-composition-error-modal.jpg" width="500" />
+<img class="screenshot" src="./img/federated-graphs/federated-graph-composition-error-modal.jpg" alt="Studio screenshot showing the composition error modal that is opened by clicking the Federated label in error state" width="500" />
 
 > [Learn more about composition errors](https://www.apollographql.com/docs/federation/errors/)

--- a/studio-docs/source/getting-started.mdx
+++ b/studio-docs/source/getting-started.mdx
@@ -32,7 +32,7 @@ In Studio, each **graph** corresponds to a data graph and its associated GraphQL
 
     The list of organizations you belong to appears in the left column:
 
-    <img src="./img//organization-list.png" class="screenshot" alt="Schema history tab in Studio"></img>
+    <img src="./img//organization-list.png" class="screenshot" alt="Schema history tab in Studio" />
 
 2. Select the organization that you want to add your graph to. Then, click **New Graph** in the upper right.
 

--- a/studio-docs/source/notification-setup.md
+++ b/studio-docs/source/notification-setup.md
@@ -31,10 +31,10 @@ Currently, Studio can send each of these notification types to the channel(s) in
 2. Select the **Notifications** tab.
 3. Click **Add notification** in the upper right.
 4. Choose a notification type and click **Next**.
-    <img src="./img/add-notification.jpg" class="screenshot" width="500" alt="Notification creation modal">
+    <img src="./img/add-notification.jpg" class="screenshot" width="500" alt="Notification creation modal" />
 5. In the dropdown, select which [variant](./org/graphs/#managing-variants) of your graph you want to receive notifications for.
 6. Select an existing configured channel to send notifications to, or select which type of new channel you want to configure:
-    <img src="./img/create-new-channel.jpg" class="screenshot" width="400" alt="Notification creation modal">
+    <img src="./img/create-new-channel.jpg" class="screenshot" width="400" alt="Notification creation modal" />
 7. Click **Next**.
 8. If you're configuring a new channel, complete the steps in [Configuring a new channel](#configuring-a-new-channel).
 9. If you're creating a daily report, select a time zone. The report is sent daily at 9am in the selected time zone.
@@ -65,7 +65,7 @@ You can repeat this process to create webhook URLs for different Slack channels.
 
 #### 2. Provide the Slack hook to Studio
 
-<img src="./img/integrations/slack_creation.png" width="500" class="screenshot" alt="Slack Creation Modal">
+<img src="./img/integrations/slack_creation.png" width="500" class="screenshot" alt="Slack Creation Modal" />
 
 1. Back in Studio, specify a name for this notification channel in the Channel Name field. This name must be unique among your graph's notification channels.
 
@@ -101,7 +101,7 @@ Generate an [integration key](https://support.pagerduty.com/docs/generating-api-
 
 #### 2. Provide the integration key to Studio
 
-<img src="./img/integrations/pd_creation.png" width="500" class="screenshot" alt="Slack Creation Modal">
+<img src="./img/integrations/pd_creation.png" width="500" class="screenshot" alt="Slack Creation Modal" />
 
 1. Back in Studio, specify a name for this notification channel in the Channel Name field. This name must be unique among your graph's notification channels.
 
@@ -117,7 +117,7 @@ Generate an [integration key](https://support.pagerduty.com/docs/generating-api-
 
 Custom webhooks require you to set up an HTTPS endpoint that is accessible via the public internet. Webhook notifications are sent to this endpoint as `POST` requests. Notification details are provided as JSON in the request body, as described in [Webhook format](./schema-change-integration/#webhook-format).
 
-<img src="./img/integrations/webhook_creation.png" class="screenshot" alt="Webhook creation modal">
+<img src="./img/integrations/webhook_creation.png" class="screenshot" alt="Webhook creation modal" />
 
 1. Specify a name for this notification channel in the Channel Name field. This name must be unique among of your graph's notification channels.
 2. In the Webhook URL field, provide the URL of your HTTP(S) endpoint.

--- a/studio-docs/source/org/graphs.mdx
+++ b/studio-docs/source/org/graphs.mdx
@@ -40,7 +40,7 @@ Apollo Studio provides a powerful **Explorer** IDE that helps you visualize your
 
 The History view in Apollo Studio lets you view the timeline of changes made to your graph's schema:
 
-<img src="../img//schema-history.jpg" class="screenshot" alt="Studio History view" width="400"></img>
+<img src="../img//schema-history.jpg" class="screenshot" alt="Studio History view" width="400" />
 
 **Only schema changes that you push to Studio are included in this timeline**, which is one of the most important reasons to [include schema registration in your continuous delivery pipeline](../schema/cli-registration/#registering-with-continuous-delivery).
 

--- a/studio-docs/source/performance-alerts.md
+++ b/studio-docs/source/performance-alerts.md
@@ -7,7 +7,7 @@ sidebar_title: Performance alerts (experimental)
 
 Apollo Studio can notify your team's Slack workspace or Pagerduty instance whenever a particular metric (such as error rate) for a particular GraphQL operation exceeds a defined threshold. This is useful for detecting anomalies, especially following a release.
 
-<img src="./img/integrations/slack-notification.png" width="500" class="screenshot" alt="Performance alert">
+<img src="./img/integrations/slack-notification.png" width="500" class="screenshot" alt="Performance alert" />
 
 ## Supported metrics
 
@@ -26,7 +26,7 @@ Each performance alert you define can apply to either **a specific operation** o
 1. Go to your graph's Settings page in [Apollo Studio](https://studio.apollographql.com/).
 2. Select the **Notifications** tab and scroll to the bottom of the page:
 
-   <img src="./img/integrations/perf_alert_setup.png" class="screenshot" alt="Performance alert">
+   <img src="./img/integrations/perf_alert_setup.png" class="screenshot" alt="Performance alert" />
 
 2. Click **Add new alert**.
 3. Configure the alert's **Operation Name**, **Trigger**, and **Trigger Value** to suit your needs.

--- a/studio-docs/source/schema-change-integration.md
+++ b/studio-docs/source/schema-change-integration.md
@@ -4,7 +4,7 @@ title: Schema change notifications
 
 You can [configure Apollo Studio](./notification-setup) to notify your team whenever any changes (additions, deprecations, removals, etc.) are made to your graph's registered schema:
 
-<img class="screenshot" src="./img/integrations/schema-notification.jpg" alt="Schema notification Slack message." width="400"></img>
+<img class="screenshot" src="./img/integrations/schema-notification.jpg" alt="Schema notification Slack message." width="400" />
 
 You can configure separate change notifications for each [variant](./org/graphs/#managing-variants) of your graph.
 

--- a/studio-docs/source/schema-checks.mdx
+++ b/studio-docs/source/schema-checks.mdx
@@ -68,7 +68,7 @@ Each change to the schema is labeled either `PASS` or `FAIL`.
 The CLI output also includes a Studio URL that provides full details on the changes and their impact on existing clients and operations:
 
 
-<img class="screenshot" src="./img/schema-checks/service-check-page.png" alt="Service check page in Apollo Studio"></img>
+<img class="screenshot" src="./img/schema-checks/service-check-page.png" alt="Service check page in Apollo Studio" />
 
 
 > **Note:** If you've [integrated schema checks with your GitHub PRs](#integrating-with-github), the "Details" link in your GitHub check takes you to this same details page.
@@ -79,7 +79,7 @@ Occasionally, schema checks might flag a change that you know is safe. For examp
 
 In cases like this, you can **override** a flagged change in Apollo Studio from the associated check's details page:
 
-<img class="screenshot" src="./img/schema-checks/mark-operation.png" alt="Service check page in Apollo Studio"></img>
+<img class="screenshot" src="./img/schema-checks/mark-operation.png" alt="Service check page in Apollo Studio" />
 
 You override flagged changes on an operation-by-operation basis. For each operation with flagged changes, you can override those changes in the following ways:
 
@@ -94,7 +94,7 @@ You can also rerun checks from inside Studio. When you rerun a check, the latest
 
 > **Note:** If you've [integrated schema checks with your GitHub PRs](#integrating-with-github), a rerun of the check also updates the status of the check in Github.
 
-<img class="screenshot" src="./img/schema-checks/rerun-check.png" alt="Rerun check in Apollo Studio"></img>
+<img class="screenshot" src="./img/schema-checks/rerun-check.png" alt="Rerun check in Apollo Studio" />
 
 ### Checking a federated schema
 
@@ -148,7 +148,7 @@ jobs:
 If you're using GitHub, you can install the [Apollo Studio GitHub app](https://github.com/apps/apollo-studio). This app enables Apollo Studio to send a webhook back to your GitHub project on each call to `apollo service:check`, providing built-in pass/fail status checks on your pull requests:
 
 
-<img class="screenshot" src="./img/schema-checks/github-check.png" alt="GitHub Status View"></img>
+<img class="screenshot" src="./img/schema-checks/github-check.png" alt="GitHub Status View" />
 
 
 ### Integrating with other version control services

--- a/studio-docs/source/setup-analytics.mdx
+++ b/studio-docs/source/setup-analytics.mdx
@@ -27,7 +27,7 @@ After you obtain a graph API key, assign it to the `APOLLO_KEY` environment vari
 
 Now the next time you start your production server, it will automatically begin pushing trace data to Studio:
 
-<img src="./img//metrics.jpg" class="screenshot" alt="Apollo Studio metrics view"></img>
+<img src="./img//metrics.jpg" class="screenshot" alt="Apollo Studio metrics view" />
 
 You can also push trace data from environments besides production, such as a staging or beta server. To keep this data separate from your production data, learn how to [create variants of your graph](./org/graphs/#managing-variants).
 


### PR DESCRIPTION
In #1134 I added the Federated graphs in Studio article, but I forgot to include alt tags on the screenshots. Accessibility is very important. 🙏 This PR remedies that oversight.

Also fixes the image tags in several files where they were not self closing, or forgot the trailing slash. ✨ 