### PR TITLE
Fix: book-trips.tsx error

### DIFF
--- a/docs/source/tutorial/local-state.mdx
+++ b/docs/source/tutorial/local-state.mdx
@@ -404,7 +404,7 @@ import * as GetCartItemsTypes from '../pages/__generated__/GetCartItems';
 import * as BookTripsTypes from './__generated__/BookTrips';
 
 export const BOOK_TRIPS = gql`
-  mutation BookTrips($launchIds: [ID]!) {
+  mutation BookTrips($launchIds: [ID!]!) {
     bookTrips(launchIds: $launchIds) {
       success
       message


### PR DESCRIPTION
Missing '!' causes "Variable $launchIds of type [ID]! used in position expecting type [ID!]." error on book-trips.tsx