### PR TITLE
Changes to request headers in Explorer

### DIFF
--- a/studio-docs/source/explorer.mdx
+++ b/studio-docs/source/explorer.mdx
@@ -103,14 +103,6 @@ The Explorer currently enables you to authenticate via [request headers](#reques
 
 The bottom of the Explorer editor provides a Headers section where you can set headers that are included in your operation's HTTP request.
 
-For example, you can provide a bearer token in an `Authentication` header like so:
-
-```json
-{
-  "Authentication": "bearer <TOKEN>"
-}
-```
-
 > **Beta feature:** You can specify default headers that are applied to _every_ Explorer request executed by _every_ user in your organization. This can be useful if you want to provide a consistent identifier to your server for requests coming from the Explorer. To request access to this beta feature, please contact **support@apollographql.com**.
 
 #### Cookies


### PR DESCRIPTION
We no longer support using JSON for setting or storing request headers. 