### PR TITLE
Update data-source.md blog link

### DIFF
--- a/docs/source/tutorial/data-source.md
+++ b/docs/source/tutorial/data-source.md
@@ -31,7 +31,7 @@ module.exports = LaunchAPI;
 
 The `RESTDataSource` class automatically caches responses from REST resources with no additional setup. We call this feature **partial query caching**. It enables you to take advantage of the caching logic that the REST API already exposes.
 
-> To learn more about partial query caching with Apollo data sources, check out [this blog post](https://blog.apollographql.com/easy-and-performant-graphql-over-rest-e02796993b2b).
+> To learn more about partial query caching with Apollo data sources, check out [this blog post](https://www.apollographql.com/blog/backend/easy-and-performant-graphql-over-rest-e02796993b2b/).
 
 ### Write data-fetching methods
 


### PR DESCRIPTION
The old URL led to a 404, so I googled the title and this is the link that I'm pretty sure replaces it.