### PR TITLE
(docs) Replace spectrum reference with Apollo GraphQL Community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ This is the main repository for discussion and coordination - the code will live
 
 - Check out the [homepage](http://www.apollographql.com/)
 - Stay up to date by reading our [posts on Medium](https://blog.apollographql.com/)
-- [Join us on Spectrum!](https://spectrum.chat/apollo)
+- [Join our Apollo GraphQL Community!](https://community.apollographql.com/)


### PR DESCRIPTION
Replacing the reference to spectrum.chat with the new [Apollo GraphQL Community forums](https://community.apollographql.com/)