### PR TITLE
Deploy deploy previews at /

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[context.deploy-preview]
+  command = "gatsby build"


### PR DESCRIPTION
This branch tells netlify to deploy our docs deploy previews at / instead of nesting them in the location we expect them to be in prod.