### PR TITLE
chore: removes outdated info about CLI

### DIFF
--- a/studio-docs/source/schema/cli-registration.mdx
+++ b/studio-docs/source/schema/cli-registration.mdx
@@ -9,7 +9,7 @@ import RegisterFederatedCli from '../../shared/register-federated-cli.mdx'
 
 If you're using a GraphQL server that doesn't support [schema reporting](./schema-reporting/), you can register your schema via the [Rover CLI](https://www.apollographql.com/docs/rover/).
 
-> **Do not use both schema reporting and Rover to register schemas for the same graph.** Doing so can cause you to register "no-op" schema changes that are semantically identical but cosmetically different. For example, schema reporting preserves a schema's comments and directives, whereas CLI registration does not.
+> **Do not use both schema reporting and Rover to register schemas for the same graph.** Doing so can cause you to register "no-op" schema changes that are semantically identical but cosmetically different.
 
 ## Registering a non-federated schema
 


### PR DESCRIPTION
The old CLI stripped comments and directives from SDL before publish, but Rover only does this when publishing from an introspection result.