### PR TITLE
How contract supergraph schemas work

### DIFF
--- a/studio-docs/source/contracts.mdx
+++ b/studio-docs/source/contracts.mdx
@@ -44,7 +44,7 @@ graph BT;
 
 This enables you to hide experimental types and fields that are still in development, or to limit a particular audience's access to only the portions of your graph that they need.
 
-Contract gateways can safely connect to the same subgraph instances as any other gateway, because they can only interact with data that's represented in the contract schema. This will not affect internal routing (e.g. usage of hidden fields in `@requires` selection sets). Additionally, any `@tag` labels that are part of the source variant's supergraph schema will be maintained on a contract supergraph schema.
+Contract gateways can safely connect to the same subgraph instances as any other gateway, because they can only interact with data that's represented in the contract schema. This does not affect internal routing (e.g. usage of hidden fields in `@requires` selection sets). Additionally, any `@tag` labels that are part of the source variant's supergraph schema are preserved in a contract supergraph schema.
 
 ### Contract documentation
 


### PR DESCRIPTION
Clarify that contract gateways can still use elided fields for internal routing and that @tag directive labels are maintained