### PR TITLE
🐛 Embedded Explorer: add correct args matching fetch to handleRequest

### DIFF
--- a/studio-docs/source/embed-explorer.mdx
+++ b/studio-docs/source/embed-explorer.mdx
@@ -91,7 +91,7 @@ The `EmbeddedExplorer` object takes an options object with the following structu
       theme: 'light',
     },
   },
-  handleRequest: () => {
+  handleRequest: (endpointUrl, options) => {
     return fetch(endpointUrl, {
       ...options,
       headers: {


### PR DESCRIPTION
I left out the args in this function!