### PR TITLE
(docs) Add buildSucceeded property to build status notification event

### DIFF
--- a/studio-docs/source/build-status-notification.md
+++ b/studio-docs/source/build-status-notification.md
@@ -34,6 +34,7 @@ interface ResponseShape {
   eventType: 'BUILD_STATUS_UPDATE';
   eventID: string;
   supergraphSchemaURL: string | undefined; // See description below
+  buildSucceeded: boolean;
   buildErrors: BuildError[] | undefined; // See description below
   graphID: string;
   variantID: string; // See description below


### PR DESCRIPTION
Adding the `buildSucceeded: boolean` property to the ResponseShape interface used with the build status notification webhook