### PR TITLE
contracts: Fix example markdown highlighted area

### DIFF
--- a/studio-docs/source/contracts.mdx
+++ b/studio-docs/source/contracts.mdx
@@ -79,7 +79,7 @@ With contracts, you apply **tags** to types and fields in your subgraph schemas 
 
 For example, let's take a look at this Products subgraph schema:
 
-```graphql{1-6,18-21}:title=products.graphql
+```graphql{1-4,18-21}:title=products.graphql
 # You must include this definition in any schema with tags!
 directive @tag(
   name: String!

--- a/studio-docs/source/contracts.mdx
+++ b/studio-docs/source/contracts.mdx
@@ -79,7 +79,7 @@ With contracts, you apply **tags** to types and fields in your subgraph schemas 
 
 For example, let's take a look at this Products subgraph schema:
 
-```graphql{1-4,15-18}:title=products.graphql
+```graphql{1-4,16-19}:title=products.graphql
 # You must include this definition in any schema with tags!
 directive @tag(
   name: String!

--- a/studio-docs/source/contracts.mdx
+++ b/studio-docs/source/contracts.mdx
@@ -79,7 +79,7 @@ With contracts, you apply **tags** to types and fields in your subgraph schemas 
 
 For example, let's take a look at this Products subgraph schema:
 
-```graphql{1-4,18-21}:title=products.graphql
+```graphql{1-4,15-18}:title=products.graphql
 # You must include this definition in any schema with tags!
 directive @tag(
   name: String!


### PR DESCRIPTION
Fixes the line numbers that are highlighted in the GraphQL markdown example in contracts docs