### PR TITLE
Fix a wrong schema example in docs/source/tutorial/mutations.mdx

### DIFF
--- a/docs/source/tutorial/mutations.mdx
+++ b/docs/source/tutorial/mutations.mdx
@@ -18,7 +18,7 @@ As a reminder, mutations are GraphQL operations that can modify back-end data (u
 type Mutation {
   bookTrips(launchIds: [ID]!): TripUpdateResponse!
   cancelTrip(launchId: ID!): TripUpdateResponse!
-  login(email: String): String # login token
+  login(email: String): User # login token
 }
 ```
 


### PR DESCRIPTION
# About

I found the mistake in a page [Update data with mutations](https://www.apollographql.com/docs/tutorial/mutations/) in full stack tutorial.

## Fixed point

`Mutation`'s `login` return `String` but it must return `User`. The correct schema is defined in a page [Build a schema](https://www.apollographql.com/docs/tutorial/schema/)

```diff
# YOU DON'T NEED TO COPY THIS.
type Mutation {
  bookTrips(launchIds: [ID]!): TripUpdateResponse!
  cancelTrip(launchId: ID!): TripUpdateResponse!
- login(email: String): String # login token
+ login(email: String): User # login token
}
```