### PR TITLE
data-privacy: remove reference to old extensions

### DIFF
--- a/studio-docs/source/data-privacy.md
+++ b/studio-docs/source/data-privacy.md
@@ -72,11 +72,8 @@ Let’s walk through Apollo Server's default behavior for reporting on fields in
 // GraphQL Response
 {
   "data": { ... },          // NEVER sent to Apollo Studio.
-  "errors": [ ... ],        // Sent to Studio, used to report on errors for operations and fields.
-  "extensions": {
-    "tracing": { ... },     // Sent to Studio, used to report on performance data for operations and fields.
-    "cacheControl": { ... } // Sent to Studio, used to determine cache policies and forward CDN cache headers.
-  }
+  "errors": [ ... ] 
+  // Sent to Studio, used to report on errors for operations and fields.
 }
 ```
 


### PR DESCRIPTION
These were old things included in responses from graphs to the old engineproxy and aren't used these days.